### PR TITLE
Fix compile errors and align session service

### DIFF
--- a/migration/src/m20250501_000001_create_adk_tables.rs
+++ b/migration/src/m20250501_000001_create_adk_tables.rs
@@ -114,8 +114,8 @@ impl MigrationTrait for Migration {
                     .foreign_key(
                         ForeignKey::create()
                             .name("fk_events_sessions")
-                            .from(Events::Table, vec![Events::AppName, Events::UserId, Events::SessionId])
-                            .to(Sessions::Table, vec![Sessions::AppName, Sessions::UserId, Sessions::Id])
+                            .from(Events::Table, (Events::AppName, Events::UserId, Events::SessionId))
+                            .to(Sessions::Table, (Sessions::AppName, Sessions::UserId, Sessions::Id))
                             .on_delete(ForeignKeyAction::Cascade)
                     )
                     .to_owned(),
@@ -171,8 +171,8 @@ impl MigrationTrait for Migration {
                     .foreign_key(
                         ForeignKey::create()
                             .name("fk_artifacts_sessions")
-                            .from(Artifacts::Table, vec![Artifacts::AppName, Artifacts::UserId, Artifacts::SessionId])
-                            .to(Sessions::Table, vec![Sessions::AppName, Sessions::UserId, Sessions::Id])
+                            .from(Artifacts::Table, (Artifacts::AppName, Artifacts::UserId, Artifacts::SessionId))
+                            .to(Sessions::Table, (Sessions::AppName, Sessions::UserId, Sessions::Id))
                             .on_delete(ForeignKeyAction::Cascade)
                     )
                     .to_owned(),

--- a/scroll_core/src/models/mod.rs
+++ b/scroll_core/src/models/mod.rs
@@ -1,2 +1,4 @@
 pub mod base_model;
 pub mod model_registry;
+pub mod scroll_session;
+pub mod scroll_event;

--- a/scroll_core/src/sessions/error.rs
+++ b/scroll_core/src/sessions/error.rs
@@ -1,0 +1,24 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum SessionError {
+    NotFound,
+    Db(sea_orm::DbErr),
+}
+
+impl fmt::Display for SessionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SessionError::NotFound => write!(f, "session not found"),
+            SessionError::Db(err) => write!(f, "database error: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+impl From<sea_orm::DbErr> for SessionError {
+    fn from(err: sea_orm::DbErr) -> Self {
+        SessionError::Db(err)
+    }
+}

--- a/scroll_core/src/sessions/in_memory_session_service.rs
+++ b/scroll_core/src/sessions/in_memory_session_service.rs
@@ -3,6 +3,7 @@ use crate::sessions::session_service::{GetSessionConfig, ListEventsResponse, Lis
 use crate::events::scroll_event::ScrollEvent;
 
 use std::collections::HashMap;
+use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
 use chrono::Utc;
 use std::error::Error;
@@ -20,8 +21,9 @@ impl InMemorySessionService {
     }
 }
 
+#[async_trait]
 impl SessionService for InMemorySessionService {
-    fn create_session(
+    async fn create_session(
         &self,
         app_name: &str,
         user_id: &str,
@@ -39,7 +41,7 @@ impl SessionService for InMemorySessionService {
         Ok(session)
     }
 
-    fn get_session(
+    async fn get_session(
         &self,
         _app_name: &str,
         _user_id: &str,
@@ -49,7 +51,7 @@ impl SessionService for InMemorySessionService {
         Ok(self.store.lock().unwrap().get(session_id).cloned())
     }
 
-    fn list_sessions(
+    async fn list_sessions(
         &self,
         app_name: &str,
         user_id: &str,
@@ -66,7 +68,7 @@ impl SessionService for InMemorySessionService {
         Ok(ListSessionsResponse { sessions })
     }
 
-    fn delete_session(
+    async fn delete_session(
         &self,
         app_name: &str,
         user_id: &str,
@@ -82,7 +84,7 @@ impl SessionService for InMemorySessionService {
         Ok(())
     }
 
-    fn append_event(
+    async fn append_event(
         &self,
         session: &mut ScrollSession,
         event: ScrollEvent,
@@ -92,7 +94,7 @@ impl SessionService for InMemorySessionService {
         Ok(event)
     }
 
-    fn list_events(
+    async fn list_events(
         &self,
         app_name: &str,
         user_id: &str,
@@ -113,7 +115,7 @@ impl SessionService for InMemorySessionService {
         })
     }
 
-    fn close_session(
+    async fn close_session(
         &self,
         _session: &mut ScrollSession,
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/scroll_core/src/sessions/mod.rs
+++ b/scroll_core/src/sessions/mod.rs
@@ -5,3 +5,4 @@ pub mod session_event_log;
 pub mod session_file;
 pub mod session_service;
 pub mod state;
+pub mod error;

--- a/scroll_core/src/sessions/session_service.rs
+++ b/scroll_core/src/sessions/session_service.rs
@@ -6,6 +6,7 @@
 
 use crate::sessions::session::ScrollSession;
 use std::collections::HashMap;
+use async_trait::async_trait;
 
 use crate::events::scroll_event::ScrollEvent;
 
@@ -29,8 +30,9 @@ pub struct ListEventsResponse {
 }
 
 /// Trait for session backends (in-memory, database, etc).
+#[async_trait]
 pub trait SessionService {
-    fn create_session(
+    async fn create_session(
         &self,
         app_name: &str,
         user_id: &str,
@@ -38,7 +40,7 @@ pub trait SessionService {
         session_id: Option<String>,
     ) -> Result<ScrollSession, Box<dyn Error>>;
 
-    fn get_session(
+    async fn get_session(
         &self,
         app_name: &str,
         user_id: &str,
@@ -46,13 +48,13 @@ pub trait SessionService {
         config: Option<GetSessionConfig>,
     ) -> Result<Option<ScrollSession>, Box<dyn Error>>;
 
-    fn list_sessions(
+    async fn list_sessions(
         &self,
         app_name: &str,
         user_id: &str,
     ) -> Result<ListSessionsResponse, Box<dyn Error>>;
 
-    fn delete_session(
+    async fn delete_session(
         &self,
         app_name: &str,
         user_id: &str,
@@ -60,20 +62,20 @@ pub trait SessionService {
         config: Option<GetSessionConfig>,
     ) -> Result<(), Box<dyn Error>>;
 
-    fn list_events(
+    async fn list_events(
         &self,
         app_name: &str,
         user_id: &str,
         session_id: &str,
     ) -> Result<ListEventsResponse, Box<dyn Error>>;
 
-    fn append_event(
+    async fn append_event(
         &self,
         session: &mut ScrollSession,
         event: ScrollEvent,
     ) -> Result<ScrollEvent, Box<dyn Error>>;
 
-    fn close_session(
+    async fn close_session(
         &self,
         session: &mut ScrollSession,
     ) -> Result<(), Box<dyn Error>>;

--- a/scroll_core/src/sessions/state.rs
+++ b/scroll_core/src/sessions/state.rs
@@ -22,6 +22,12 @@ pub struct State {
     delta: HashMap<String, String>,
 }
 
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.to_full_map())
+    }
+}
+
 impl State {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
## Summary
- fix foreign key arrays to tuples for SeaORM
- export SessionError and state Display impl
- align session service trait/implementations with async signatures
- fix runner lifetime issue with boxed streams

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68534fe2498083308f257b5977e73ad6