### PR TITLE
Implement trigger loop features

### DIFF
--- a/scroll_core/src/invocation/named_construct.rs
+++ b/scroll_core/src/invocation/named_construct.rs
@@ -4,11 +4,21 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-
 use crate::invocation::invocation::{Invocation, InvocationResult};
 use crate::scroll::Scroll;
 
+pub trait PulseSensitive {
+    fn should_awaken(&self, tick: u64) -> bool;
+}
+
 pub trait NamedConstruct {
     fn name(&self) -> &str;
-    fn perform(&self, invocation: &Invocation, scroll: Option<Scroll>) -> Result<InvocationResult, String>;
+    fn perform(
+        &self,
+        invocation: &Invocation,
+        scroll: Option<Scroll>,
+    ) -> Result<InvocationResult, String>;
+    fn as_pulse_sensitive(&self) -> Option<&dyn PulseSensitive> {
+        None
+    }
 }

--- a/scroll_core/src/trigger_loom/config.rs
+++ b/scroll_core/src/trigger_loom/config.rs
@@ -1,0 +1,76 @@
+// ===============================
+// src/trigger_loom/config.rs
+// ===============================
+
+use crate::EmotionSignature;
+use chrono::{Local, TimeZone, Timelike};
+
+#[derive(Debug, Clone)]
+pub enum SymbolicRhythm {
+    Constant(f32), // Hz
+    Dawn,
+    Dusk,
+    Spiral(u32), // Recursive step rhythm
+    EmotionDriven,
+}
+
+#[derive(Debug, Clone)]
+pub struct TriggerLoopConfig {
+    pub rhythm: SymbolicRhythm,
+    pub max_invocations_per_tick: usize,
+    pub allow_test_ticks: bool,
+    pub emotional_signature: Option<EmotionSignature>,
+}
+
+pub fn modulate_frequency(base: f32, emotion: &EmotionSignature) -> f32 {
+    match emotion.intensity.unwrap_or(0.0).round() as i32 {
+        0 => base * 0.5,
+        1 => base * 0.8,
+        2 => base,
+        3 => base * 1.5,
+        _ => base * 2.0,
+    }
+}
+
+impl TriggerLoopConfig {
+    pub fn resolve_frequency(&self) -> f32 {
+        self.resolve_frequency_at(Local::now())
+    }
+
+    pub fn resolve_frequency_at<Tz: TimeZone>(&self, now: chrono::DateTime<Tz>) -> f32 {
+        match &self.rhythm {
+            SymbolicRhythm::Constant(hz) => *hz,
+            SymbolicRhythm::EmotionDriven => {
+                if let Some(emotion) = &self.emotional_signature {
+                    modulate_frequency(1.0, emotion)
+                } else {
+                    1.0
+                }
+            }
+            SymbolicRhythm::Dawn => {
+                let hour = now.with_timezone(&Local).hour();
+                if hour >= 22 || hour < 6 {
+                    0.0
+                } else {
+                    1.0
+                }
+            }
+            SymbolicRhythm::Dusk => {
+                let hour = now.with_timezone(&Local).hour();
+                if (6..18).contains(&hour) {
+                    0.0
+                } else {
+                    1.0
+                }
+            }
+            SymbolicRhythm::Spiral(n) => {
+                let step = *n as f32;
+                if step == 0.0 {
+                    1.0
+                } else {
+                    1.0 / step
+                }
+            }
+        }
+    }
+}

--- a/scroll_core/src/trigger_loom/engine.rs
+++ b/scroll_core/src/trigger_loom/engine.rs
@@ -1,0 +1,112 @@
+// ===============================
+// src/trigger_loom/engine.rs
+// ===============================
+
+use std::collections::HashMap;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use log::info;
+use uuid::Uuid;
+
+use crate::core::cost_manager::{CostDecision, CostManager};
+use crate::invocation::invocation::{Invocation, InvocationMode, InvocationTier};
+use crate::invocation::named_construct::{NamedConstruct, PulseSensitive};
+use crate::trigger_loom::config::{SymbolicRhythm, TriggerLoopConfig};
+use crate::trigger_loom::loom::evaluate_construct;
+
+const MAX_AGENT_DEPTH: u32 = 5;
+
+pub struct TriggerLoopEngine {
+    config: TriggerLoopConfig,
+    tick_counter: u64,
+    agent_depth: HashMap<String, u32>,
+}
+
+impl TriggerLoopEngine {
+    pub fn new(config: TriggerLoopConfig) -> Self {
+        Self {
+            config,
+            tick_counter: 0,
+            agent_depth: HashMap::new(),
+        }
+    }
+
+    pub fn start_loop(&mut self, constructs: &mut [Box<dyn NamedConstruct>]) {
+        let base_freq = self.config.resolve_frequency();
+        let interval = Duration::from_secs_f32(1.0 / base_freq.max(0.001));
+
+        loop {
+            let now = Instant::now();
+            self.tick_once(constructs);
+            let elapsed = now.elapsed();
+            if elapsed < interval {
+                thread::sleep(interval - elapsed);
+            }
+        }
+    }
+
+    pub fn tick_once(&mut self, constructs: &mut [Box<dyn NamedConstruct>]) {
+        self.tick_counter += 1;
+
+        let start = Instant::now();
+        let mut fired_count = 0usize;
+        let mut skipped = 0usize;
+
+        for construct in constructs.iter_mut() {
+            if fired_count >= self.config.max_invocations_per_tick {
+                break;
+            }
+
+            if let Some(pulse) = construct.as_pulse_sensitive() {
+                if pulse.should_awaken(self.tick_counter) {
+                    let invocation = Invocation {
+                        id: Uuid::new_v4(),
+                        phrase: "tick".into(),
+                        invoker: "TriggerLoop".into(),
+                        invoked: construct.name().into(),
+                        tier: InvocationTier::True,
+                        mode: InvocationMode::Read,
+                        resonance_required: false,
+                        timestamp: Utc::now(),
+                    };
+                    let cost = CostManager::assess(&invocation, &[]);
+                    match cost.decision {
+                        CostDecision::Allow => {
+                            let _ = construct.perform(&invocation, None);
+                            let depth = self
+                                .agent_depth
+                                .entry(construct.name().to_string())
+                                .or_insert(0);
+                            *depth += 1;
+                            if *depth >= MAX_AGENT_DEPTH {
+                                break;
+                            }
+                            fired_count += 1;
+                        }
+                        CostDecision::Throttle(_) => {
+                            skipped += 1;
+                        }
+                        CostDecision::Reject(_) => {
+                            info!("⏸️ rejected {} (cost)", construct.name());
+                            skipped += 1;
+                        }
+                    }
+                } else {
+                    skipped += 1;
+                }
+            } else {
+                skipped += 1;
+            }
+        }
+
+        let duration = start.elapsed().as_millis();
+        let summary = serde_json::json!({
+            "fired": fired_count,
+            "skipped": skipped,
+            "duration_ms": duration
+        });
+        info!("{}", summary.to_string());
+    }
+}

--- a/scroll_core/src/trigger_loom/mod.rs
+++ b/scroll_core/src/trigger_loom/mod.rs
@@ -2,8 +2,10 @@
 // src/trigger_loom/mod.rs
 // ===============================
 
-pub mod loom;
+pub mod config;
 pub mod emotional_state;
+pub mod engine;
 pub mod glyph_matcher;
+pub mod loom;
 pub mod recursion_control;
 pub mod trigger_loop;

--- a/scroll_core/src/trigger_loom/recursion_control.rs
+++ b/scroll_core/src/trigger_loom/recursion_control.rs
@@ -2,18 +2,33 @@
 // src/trigger_loom/recursion_control.rs
 // ===============================
 
+use std::fs::{read_to_string, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
 use crate::invocation::invocation::{Invocation, InvocationTier};
+
+fn trace_file() -> PathBuf {
+    std::env::temp_dir().join("recursion_trace.log")
+}
 
 pub fn should_recurse(tier: &InvocationTier) -> bool {
     matches!(tier, InvocationTier::Calling | InvocationTier::Whispered)
 }
 
 pub fn mark_cycle(invocation: &Invocation) {
-    // Future: Log to scroll echo trace or recursion cycle ledger
+    let path = trace_file();
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = writeln!(file, "{}", invocation.id);
+    }
     println!("🔁 Recursion marked: {}", invocation.phrase);
 }
 
 pub fn recover_trace() -> Option<String> {
-    // Placeholder for restoring recursion state
-    Some("Recovered prior recursion trace.".to_string())
+    let path = trace_file();
+    if let Ok(contents) = read_to_string(&path) {
+        contents.lines().last().map(|s| s.to_string())
+    } else {
+        None
+    }
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,0 +1,14 @@
+use chrono::{Local, TimeZone};
+use scroll_core::trigger_loom::config::{SymbolicRhythm, TriggerLoopConfig};
+
+#[test]
+fn test_dawn_frequency_night() {
+    let config = TriggerLoopConfig {
+        rhythm: SymbolicRhythm::Dawn,
+        max_invocations_per_tick: 1,
+        allow_test_ticks: true,
+        emotional_signature: None,
+    };
+    let late = Local.with_ymd_and_hms(2024, 1, 1, 23, 0, 0).unwrap();
+    assert_eq!(config.resolve_frequency_at(late), 0.0);
+}

--- a/tests/recursion_control_tests.rs
+++ b/tests/recursion_control_tests.rs
@@ -1,0 +1,35 @@
+use chrono::Utc;
+use scroll_core::invocation::invocation::{Invocation, InvocationMode, InvocationTier};
+use scroll_core::trigger_loom::recursion_control::{mark_cycle, recover_trace};
+use uuid::Uuid;
+
+#[test]
+fn test_recover_last_cycle() {
+    let path = std::env::temp_dir().join("recursion_trace.log");
+    let _ = std::fs::remove_file(&path);
+    let inv1 = Invocation {
+        id: Uuid::new_v4(),
+        phrase: "a".into(),
+        invoker: "x".into(),
+        invoked: "y".into(),
+        tier: InvocationTier::Calling,
+        mode: InvocationMode::Read,
+        resonance_required: false,
+        timestamp: Utc::now(),
+    };
+    let inv2 = Invocation {
+        id: Uuid::new_v4(),
+        phrase: "b".into(),
+        invoker: "x".into(),
+        invoked: "y".into(),
+        tier: InvocationTier::Calling,
+        mode: InvocationMode::Read,
+        resonance_required: false,
+        timestamp: Utc::now(),
+    };
+    mark_cycle(&inv1);
+    mark_cycle(&inv2);
+    let last = recover_trace().unwrap();
+    assert_eq!(last, inv2.id.to_string());
+    let _ = std::fs::remove_file(&path);
+}

--- a/tests/trigger_log.rs
+++ b/tests/trigger_log.rs
@@ -1,0 +1,49 @@
+use logtest::Logger;
+use scroll_core::invocation::invocation::{Invocation, InvocationResult};
+use scroll_core::invocation::named_construct::{NamedConstruct, PulseSensitive};
+use scroll_core::trigger_loom::config::{SymbolicRhythm, TriggerLoopConfig};
+use scroll_core::trigger_loom::engine::TriggerLoopEngine;
+
+struct Silent;
+
+impl PulseSensitive for Silent {
+    fn should_awaken(&self, _tick: u64) -> bool {
+        false
+    }
+}
+
+impl NamedConstruct for Silent {
+    fn name(&self) -> &str {
+        "silent"
+    }
+    fn perform(
+        &self,
+        _invocation: &Invocation,
+        _scroll: Option<scroll_core::Scroll>,
+    ) -> Result<InvocationResult, String> {
+        Ok(InvocationResult::Success(String::new()))
+    }
+    fn as_pulse_sensitive(&self) -> Option<&dyn PulseSensitive> {
+        Some(self)
+    }
+}
+
+#[test]
+fn test_tick_summary_logging() {
+    let logger = Logger::start();
+    let config = TriggerLoopConfig {
+        rhythm: SymbolicRhythm::Constant(1.0),
+        max_invocations_per_tick: 1,
+        allow_test_ticks: true,
+        emotional_signature: None,
+    };
+    let mut engine = TriggerLoopEngine::new(config);
+    let mut constructs: Vec<Box<dyn NamedConstruct>> = vec![Box::new(Silent)];
+    engine.tick_once(&mut constructs);
+    let logs = logger.collect();
+    let entry = logs.iter().find(|l| l.args.contains("fired")).expect("log");
+    let v: serde_json::Value = serde_json::from_str(&entry.args).unwrap();
+    assert!(v.get("fired").is_some());
+    assert!(v.get("skipped").is_some());
+    assert!(v.get("duration_ms").is_some());
+}

--- a/tests/trigger_loop_tests.rs
+++ b/tests/trigger_loop_tests.rs
@@ -1,0 +1,111 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use chrono::Utc;
+use logtest::Logger;
+use scroll_core::core::cost_manager::{self, CostDecision};
+use scroll_core::invocation::invocation::{Invocation, InvocationResult};
+use scroll_core::invocation::named_construct::{NamedConstruct, PulseSensitive};
+use scroll_core::trigger_loom::config::{SymbolicRhythm, TriggerLoopConfig};
+use scroll_core::trigger_loom::engine::TriggerLoopEngine;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct StubConstruct {
+    count: Rc<RefCell<u32>>,
+    awaken_every: u64,
+}
+
+impl PulseSensitive for StubConstruct {
+    fn should_awaken(&self, tick: u64) -> bool {
+        tick % self.awaken_every == 0
+    }
+}
+
+impl NamedConstruct for StubConstruct {
+    fn name(&self) -> &str {
+        "stub"
+    }
+
+    fn perform(
+        &self,
+        _invocation: &Invocation,
+        _scroll: Option<scroll_core::Scroll>,
+    ) -> Result<InvocationResult, String> {
+        *self.count.borrow_mut() += 1;
+        Ok(InvocationResult::Success("ok".into()))
+    }
+
+    fn as_pulse_sensitive(&self) -> Option<&dyn PulseSensitive> {
+        Some(self)
+    }
+}
+
+#[test]
+fn test_cost_reject_skips_invocation() {
+    let logger = Logger::start();
+    cost_manager::set_test_decision(Some(CostDecision::Reject("no".into())));
+    let config = TriggerLoopConfig {
+        rhythm: SymbolicRhythm::Constant(1.0),
+        max_invocations_per_tick: 5,
+        allow_test_ticks: true,
+        emotional_signature: None,
+    };
+    let mut engine = TriggerLoopEngine::new(config);
+    let stub = StubConstruct {
+        count: Rc::new(RefCell::new(0)),
+        awaken_every: 1,
+    };
+    let mut constructs: Vec<Box<dyn NamedConstruct>> = vec![Box::new(stub.clone())];
+    engine.tick_once(&mut constructs);
+    assert_eq!(*stub.count.borrow(), 0);
+    let logs = logger.collect();
+    assert!(logs.iter().any(|r| r.args.contains("rejected stub")));
+    cost_manager::set_test_decision(None);
+}
+
+#[test]
+fn test_pulse_awaken_every_three() {
+    let config = TriggerLoopConfig {
+        rhythm: SymbolicRhythm::Constant(1.0),
+        max_invocations_per_tick: 5,
+        allow_test_ticks: true,
+        emotional_signature: None,
+    };
+    let mut engine = TriggerLoopEngine::new(config);
+    let stub = StubConstruct {
+        count: Rc::new(RefCell::new(0)),
+        awaken_every: 3,
+    };
+    let silent = StubConstruct {
+        count: Rc::new(RefCell::new(0)),
+        awaken_every: u64::MAX,
+    };
+    let mut constructs: Vec<Box<dyn NamedConstruct>> =
+        vec![Box::new(stub.clone()), Box::new(silent.clone())];
+    for _ in 0..5 {
+        engine.tick_once(&mut constructs);
+    }
+    assert_eq!(*stub.count.borrow(), 1);
+    assert_eq!(*silent.count.borrow(), 0);
+}
+
+#[test]
+fn test_recursion_depth_cap() {
+    let config = TriggerLoopConfig {
+        rhythm: SymbolicRhythm::Constant(1.0),
+        max_invocations_per_tick: 5,
+        allow_test_ticks: true,
+        emotional_signature: None,
+    };
+    let mut engine = TriggerLoopEngine::new(config);
+    let stub = StubConstruct {
+        count: Rc::new(RefCell::new(0)),
+        awaken_every: 1,
+    };
+    let mut constructs: Vec<Box<dyn NamedConstruct>> = vec![Box::new(stub.clone())];
+    for _ in 0..10 {
+        engine.tick_once(&mut constructs);
+    }
+    assert!(*stub.count.borrow() <= 5);
+}


### PR DESCRIPTION
## Summary
- add rhythmic frequency resolver for Dawn/Dusk/Spiral
- implement TriggerLoopEngine with cost-based throttling
- support PulseSensitive constructs
- persist recursion trace to temp file
- add tests for trigger loop logic and logging

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6853658088788330962393162e219103