### PR TITLE
Add cache initialization with eviction tests

### DIFF
--- a/scroll_core/src/archive/initialize.rs
+++ b/scroll_core/src/archive/initialize.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+
+use crate::archive::archive_loader::load_scrolls_from_directory;
+use crate::archive::scroll_access_log::ScrollAccess;
+use crate::cache_manager::CacheManager;
+use crate::core::cost_manager::{
+    ContextCost, CostDecision, CostProfile, InvocationCost, SystemCost,
+};
+use crate::scroll::Scroll;
+
+/// Loads the archive from the given path and seeds a cache with the scrolls.
+/// The cache size is set to match the number of loaded scrolls.
+pub fn load_with_cache<P: AsRef<Path>>(path: P) -> Result<(Vec<Scroll>, CacheManager), String> {
+    let scrolls = load_scrolls_from_directory(path)?;
+    let mut cache = CacheManager::new(scrolls.len());
+
+    for scroll in &scrolls {
+        let access = ScrollAccess::new();
+        let cost = InvocationCost {
+            context: ContextCost {
+                token_estimate: 0,
+                context_span: 0,
+                relevance_score: 0.0,
+            },
+            system: SystemCost {
+                cpu_cycles: 0.0,
+                memory_used_mb: 0.0,
+                io_ops: 0,
+                scrolls_touched: 0,
+            },
+            decision: CostDecision::Allow,
+            cost_profile: CostProfile {
+                system_pressure: 0.0,
+                token_pressure: 0.0,
+                symbolic_origin: None,
+            },
+            rejection_origin: None,
+            hesitation_signal: None,
+            poetic_rejection: None,
+            symbolic_echo: None,
+            emotion_tension: None,
+        };
+        cache.cache_scroll(scroll.clone(), &scroll.emotion_signature, &access, &cost);
+    }
+
+    Ok((scrolls, cache))
+}

--- a/scroll_core/src/archive/mod.rs
+++ b/scroll_core/src/archive/mod.rs
@@ -1,4 +1,5 @@
-pub mod archive_memory;
 pub mod archive_loader;
+pub mod archive_memory;
+pub mod initialize;
+pub mod mythic_heat;
 pub mod scroll_access_log;
-pub mod mythic_heat; 

--- a/scroll_core/src/lib.rs
+++ b/scroll_core/src/lib.rs
@@ -1,4 +1,3 @@
-
 // ===============================
 // src/lib.rs
 // ===============================
@@ -29,46 +28,36 @@ pub mod tools;
 pub mod trigger_loom;
 pub mod validator;
 
-
-pub use schema::{ScrollStatus, ScrollType, EmotionSignature, YamlMetadata};
+pub use cache_manager::CacheManager;
+pub use schema::{EmotionSignature, ScrollStatus, ScrollType, YamlMetadata};
 pub use scroll::{Scroll, ScrollOrigin};
 pub use validator::validate_scroll;
 
-pub use parser::{
-    parse_scroll, 
-    parse_scroll_from_file
-};
+pub use parser::{parse_scroll, parse_scroll_from_file};
 
-pub use state_manager::{
-    transition, 
-    try_transition, 
-    describe_status, 
-    is_valid_transition
-};
+pub use state_manager::{describe_status, is_valid_transition, transition, try_transition};
 
 pub const SCROLL_CORE_VERSION: &str = "0.1.0";
 pub const SCROLL_CORE_INVOCATION: &str = "Let structure echo symbol.";
 
-
 /// Initializes the Scroll Core system and loads the scroll archive.
 
-
-pub fn initialize_scroll_core() -> Result<Vec<Scroll>, String> {
+pub fn initialize_scroll_core() -> Result<(Vec<Scroll>, CacheManager), String> {
+    use crate::archive::initialize::load_with_cache;
     use log::info;
     use std::path::Path;
-    use crate::archive::archive_loader::load_scrolls_from_directory;
 
     let archive_path = Path::new("scrolls/");
 
     info!("🌀 Scroll Core v{} initializing...", SCROLL_CORE_VERSION);
     println!("🌀 Scroll Core v{} initializing...", SCROLL_CORE_VERSION);
 
-    let scrolls = load_scrolls_from_directory(archive_path)?;
+    let (scrolls, cache) = load_with_cache(archive_path)?;
 
     info!("✅ Loaded {} scroll(s).", scrolls.len());
     println!("✅ Loaded {} scroll(s).", scrolls.len());
 
-    Ok(scrolls)
+    Ok((scrolls, cache))
 }
 /// Optional teardown hook.
 pub fn teardown_scroll_core() {

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -1,23 +1,22 @@
-use scroll_core::invocation::invocation_manager::InvocationManager;
-use scroll_core::invocation::aelren::AelrenHerald;
-use scroll_core::{initialize_scroll_core, teardown_scroll_core};
-use scroll_core::core::context_frame_engine::{ContextFrameEngine, ContextMode};
 use scroll_core::archive::archive_memory::InMemoryArchive;
-use scroll_core::system::cli_orchestrator::run_cli;
-use scroll_core::invocation::constructs::openai_construct::{Mythscribe, OpenAIClient};
 use scroll_core::construct_ai::ConstructAI;
 use scroll_core::core::construct_registry::ConstructRegistry;
+use scroll_core::core::context_frame_engine::{ContextFrameEngine, ContextMode};
+use scroll_core::invocation::aelren::AelrenHerald;
+use scroll_core::invocation::constructs::openai_construct::{Mythscribe, OpenAIClient};
+use scroll_core::invocation::invocation_manager::InvocationManager;
+use scroll_core::system::cli_orchestrator::run_cli;
+use scroll_core::{initialize_scroll_core, teardown_scroll_core};
 
 use dotenvy::dotenv;
 use std::env;
 
-
 fn main() {
     dotenv().ok();
     println!("🔑 OPENAI key: {:?}", std::env::var("OPENAI_API_KEY"));
-    
+
     match initialize_scroll_core() {
-        Ok(scrolls) => {
+        Ok((scrolls, _cache)) => {
             println!("✨ Scroll Core is active. Awaiting construct cadence...\n");
 
             let archive = InMemoryArchive::new(scrolls.clone());

--- a/scroll_core/tests/cache_manager_tests.rs
+++ b/scroll_core/tests/cache_manager_tests.rs
@@ -1,0 +1,71 @@
+use chrono::{Duration, Utc};
+use scroll_core::archive::initialize::load_with_cache;
+use scroll_core::cache_manager::CacheManager;
+use scroll_core::{Scroll, ScrollStatus, ScrollType, YamlMetadata, EmotionSignature, ScrollOrigin};
+use scroll_core::archive::scroll_access_log::ScrollAccess;
+use scroll_core::core::cost_manager::{InvocationCost, CostDecision, CostProfile, ContextCost, SystemCost};
+use uuid::Uuid;
+use std::path::Path;
+
+fn dummy_scroll(intensity: f32) -> Scroll {
+    Scroll {
+        id: Uuid::new_v4(),
+        title: "Test".into(),
+        scroll_type: ScrollType::Canon,
+        yaml_metadata: YamlMetadata {
+            title: "Test".into(),
+            scroll_type: ScrollType::Canon,
+            emotion_signature: EmotionSignature { tone: "calm".into(), emphasis: 0.5, resonance: "gentle".into(), intensity: Some(intensity) },
+            tags: vec![],
+            last_modified: None,
+        },
+        markdown_body: "Body".into(),
+        invocation_phrase: "Invoke".into(),
+        sigil: "🔧".into(),
+        status: ScrollStatus::Draft,
+        emotion_signature: EmotionSignature { tone: "calm".into(), emphasis: 0.5, resonance: "gentle".into(), intensity: Some(intensity) },
+        linked_scrolls: vec![],
+        origin: ScrollOrigin { created: Utc::now(), authored_by: None, last_modified: Utc::now() },
+    }
+}
+
+fn zero_cost() -> InvocationCost {
+    InvocationCost {
+        context: ContextCost { token_estimate: 0, context_span: 0, relevance_score: 0.0 },
+        system: SystemCost { cpu_cycles: 0.0, memory_used_mb: 0.0, io_ops: 0, scrolls_touched: 0 },
+        decision: CostDecision::Allow,
+        cost_profile: CostProfile { system_pressure: 0.0, token_pressure: 0.0, symbolic_origin: None },
+        rejection_origin: None,
+        hesitation_signal: None,
+        poetic_rejection: None,
+        symbolic_echo: None,
+        emotion_tension: None,
+    }
+}
+
+#[test]
+fn test_cache_initialized_matches_scrolls() {
+    let path = Path::new("../tests/sample_scrolls");
+    let (scrolls, cache) = load_with_cache(path).unwrap();
+    assert_eq!(scrolls.len(), cache.count());
+}
+
+#[test]
+fn test_cache_eviction_to_max_size() {
+    let mut cache = CacheManager::new(50);
+    let cost = zero_cost();
+    let now = Utc::now();
+    let mut first_id = Uuid::nil();
+    for i in 0..55 {
+        let mut scroll = dummy_scroll(i as f32);
+        if i == 0 { first_id = scroll.id; }
+        let access = ScrollAccess {
+            first_accessed: now - Duration::seconds(100 - i as i64),
+            last_accessed: now - Duration::seconds(100 - i as i64),
+            access_count: 1,
+        };
+        cache.cache_scroll(scroll, &EmotionSignature::curious(), &access, &cost);
+    }
+    assert_eq!(cache.count(), 50);
+    assert!(!cache.ids().contains(&first_id));
+}


### PR DESCRIPTION
## Summary
- wire CacheManager into initialization via new archive initializer
- ensure cache matches archive size and supports eviction
- test cache population and eviction logic

## Testing
- `cargo test --test cache_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_6853f3a344d4833080bd4b0bad029733