### PR TITLE
Implement validation logic and environment checks

### DIFF
--- a/scroll_core/src/lib.rs
+++ b/scroll_core/src/lib.rs
@@ -79,6 +79,17 @@ pub fn teardown_scroll_core() {
 
 /// Validates scroll core environment state (placeholder).
 pub fn validate_scroll_environment() -> bool {
-    // Future check logic (e.g., required modules loaded, configs, etc.)
-    true
+    use std::env;
+    use std::fs;
+
+    dotenvy::dotenv().ok();
+
+    if env::var("OPENAI_API_KEY").is_err() {
+        return false;
+    }
+
+    match fs::read_dir("scrolls/") {
+        Ok(mut entries) => entries.next().is_some(),
+        Err(_) => false,
+    }
 }

--- a/scroll_core/src/state_manager.rs
+++ b/scroll_core/src/state_manager.rs
@@ -50,13 +50,17 @@ pub fn is_valid_transition(current: &ScrollStatus, next: &ScrollStatus) -> bool 
 }
 
 pub fn try_transition(scroll: &mut Scroll, next_status: ScrollStatus) -> Result<(), String> {
-    if is_valid_transition(&scroll.status, &next_status) {
-        transition(scroll, next_status);
-        Ok(())
-    } else {
-        Err(format!(
+    if !is_valid_transition(&scroll.status, &next_status) {
+        return Err(format!(
             "Invalid state transition: {:?} -> {:?}",
             scroll.status, next_status
-        ))
+        ));
     }
+
+    if matches!((&scroll.status, &next_status), (ScrollStatus::Draft, ScrollStatus::Active)) {
+        scroll.validate()?;
+    }
+
+    transition(scroll, next_status);
+    Ok(())
 }

--- a/scroll_core/src/validator.rs
+++ b/scroll_core/src/validator.rs
@@ -9,6 +9,10 @@ pub fn validate_scroll(metadata: &YamlMetadata) -> Result<(), String> {
         return Err("Scroll must have a non-empty title.".to_string());
     }
 
+    if matches!(metadata.scroll_type, ScrollType::Myth) && metadata.tags.is_empty() {
+        return Err("Myth scrolls must include at least one tag.".to_string());
+    }
+
     match metadata.scroll_type {
         ScrollType::Canon
         | ScrollType::Protocol

--- a/tests/environment_tests.rs
+++ b/tests/environment_tests.rs
@@ -1,0 +1,7 @@
+use scroll_core::validate_scroll_environment;
+
+#[test]
+fn test_missing_openai_key() {
+    std::env::remove_var("OPENAI_API_KEY");
+    assert!(!validate_scroll_environment());
+}

--- a/tests/state_manager_tests.rs
+++ b/tests/state_manager_tests.rs
@@ -48,3 +48,11 @@ fn test_invalid_transition() {
     let result = try_transition(&mut scroll, ScrollStatus::Archived);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_validation_on_draft_to_active() {
+    let mut scroll = dummy_scroll();
+    scroll.invocation_phrase = String::new();
+    let result = try_transition(&mut scroll, ScrollStatus::Active);
+    assert!(result.is_err());
+}

--- a/tests/validator_tests.rs
+++ b/tests/validator_tests.rs
@@ -10,6 +10,7 @@ fn test_valid_metadata() {
     emphasis: 0.5,
     resonance: "gentle".into(),
 },
+        tags: vec!["test".into()],
     };
     assert!(validate_scroll(&metadata).is_ok());
 }
@@ -24,6 +25,18 @@ fn test_empty_title() {
     emphasis: 0.5,
     resonance: "gentle".into(),
 },
+        tags: vec![],
+    };
+    assert!(validate_scroll(&metadata).is_err());
+}
+
+#[test]
+fn test_myth_requires_tags() {
+    let metadata = YamlMetadata {
+        title: "Myth Scroll".into(),
+        scroll_type: ScrollType::Myth,
+        emotion_signature: EmotionSignature::default(),
+        tags: vec![],
     };
     assert!(validate_scroll(&metadata).is_err());
 }


### PR DESCRIPTION
## Summary
- enforce tag requirement for myth scrolls
- check for OpenAI key and archive files
- validate on Draft->Active state transitions
- extend validator and state manager tests
- add environment validation test

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6853f41719608330a04b93a14f306b6d