### PR TITLE
Add module-level docs

### DIFF
--- a/scroll_core/src/archive/mod.rs
+++ b/scroll_core/src/archive/mod.rs
@@ -1,3 +1,17 @@
+//! Persistent scroll archive utilities.
+//!
+//! This module exposes functions to load scrolls from disk and track
+//! archival metrics. Typical usage:
+//!
+//! ```rust,no_run
+//! use scroll_core::archive::initialize::load_with_cache;
+//! use std::path::Path;
+//!
+//! let (scrolls, cache) = load_with_cache(Path::new("scrolls/"))?;
+//! println!("Loaded {} scrolls", scrolls.len());
+//! # Ok::<(), String>(())
+//! ```
+
 pub mod archive_loader;
 pub mod archive_memory;
 pub mod initialize;

--- a/scroll_core/src/construct_ai.rs
+++ b/scroll_core/src/construct_ai.rs
@@ -4,6 +4,28 @@
 
 #![allow(unused_imports)]
 
+//! Tools for building "Construct" AI personalities.
+//!
+//! A construct is an autonomous agent that can analyze and draft `Scroll`s.
+//! Implement the [`ConstructAI`] trait on your type to plug it into the
+//! Scroll Core runtime.
+//!
+//! ```rust,no_run
+//! use scroll_core::construct_ai::{ConstructAI, ConstructContext, ConstructResult};
+//!
+//! struct Historian;
+//!
+//! impl ConstructAI for Historian {
+//!     fn reflect_on_scroll(&self, ctx: &ConstructContext) -> ConstructResult {
+//!         // inspect ctx.scrolls and return an insight
+//!         ConstructResult::Refusal { reason: String::from("todo"), echo: None }
+//!     }
+//!     fn suggest_scroll(&self, _ctx: &ConstructContext) -> ConstructResult { todo!() }
+//!     fn perform_scroll_action(&self, _ctx: &ConstructContext) -> ConstructResult { todo!() }
+//!     fn name(&self) -> &str { "historian" }
+//! }
+//! ```
+
 use crate::schema::EmotionSignature;
 use crate::scroll::Scroll;
 use uuid::Uuid;

--- a/scroll_core/src/trigger_loom/mod.rs
+++ b/scroll_core/src/trigger_loom/mod.rs
@@ -2,6 +2,24 @@
 // src/trigger_loom/mod.rs
 // ===============================
 
+//! The Trigger Loom orchestrates event-driven constructs.
+//!
+//! Use [`engine::TriggerLoopEngine`] to register triggers and execute loops.
+//!
+//! ```rust,no_run
+//! use scroll_core::trigger_loom::engine::TriggerLoopEngine;
+//! use scroll_core::trigger_loom::config::{TriggerLoopConfig, SymbolicRhythm};
+//!
+//! let config = TriggerLoopConfig {
+//!     rhythm: SymbolicRhythm::Constant(1.0),
+//!     max_invocations_per_tick: 10,
+//!     allow_test_ticks: true,
+//!     emotional_signature: None,
+//! };
+//! let mut engine = TriggerLoopEngine::new(config);
+//! engine.tick_once(&mut []);
+//! ```
+
 pub mod config;
 pub mod emotion;
 pub mod emotional_state;


### PR DESCRIPTION
## Summary
- document `construct_ai` module with overview and example
- add introduction and demo snippet for `trigger_loom`
- explain archive utilities and show loading snippet

## Testing
- `cargo doc --no-deps`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685413f2bcf0833093d43de1f8e63817