### PR TITLE
Fix demo run compile errors

### DIFF
--- a/scroll_core/src/chat/chat_dispatcher.rs
+++ b/scroll_core/src/chat/chat_dispatcher.rs
@@ -12,6 +12,7 @@ use crate::orchestra::AgentMessage;
 use crate::schema::EmotionSignature;
 use crate::scroll::Scroll;
 use crate::trigger_loom::emotional_state::EmotionalState;
+use crate::core::context_frame_engine::ContextFrameEngine;
 use chrono::Utc;
 use log::info;
 use uuid::Uuid;
@@ -19,6 +20,11 @@ use uuid::Uuid;
 pub struct ChatDispatcher;
 
 impl ChatDispatcher {
+    #[allow(deprecated)]
+    pub fn new(_manager: &InvocationManager, _engine: &ContextFrameEngine) -> Self {
+        ChatDispatcher
+    }
+
     pub fn dispatch(
         session: &mut ChatSession,
         user_input: &str,

--- a/scroll_core/src/lib.rs
+++ b/scroll_core/src/lib.rs
@@ -38,6 +38,8 @@ pub use validator::validate_scroll;
 
 pub use parser::{parse_scroll, parse_scroll_from_file};
 
+use anyhow::Result;
+
 pub use state_manager::{describe_status, is_valid_transition, transition, try_transition};
 
 pub const SCROLL_CORE_VERSION: &str = "0.1.0";
@@ -45,7 +47,7 @@ pub const SCROLL_CORE_INVOCATION: &str = "Let structure echo symbol.";
 
 /// Initializes the Scroll Core system and loads the scroll archive.
 
-pub fn initialize_scroll_core() -> Result<(Vec<Scroll>, CacheManager), String> {
+pub fn initialize_scroll_core() -> Result<(Vec<Scroll>, CacheManager)> {
     use crate::archive::initialize::load_with_cache;
     use log::info;
     use std::path::Path;
@@ -55,7 +57,7 @@ pub fn initialize_scroll_core() -> Result<(Vec<Scroll>, CacheManager), String> {
     info!("🌀 Scroll Core v{} initializing...", SCROLL_CORE_VERSION);
     println!("🌀 Scroll Core v{} initializing...", SCROLL_CORE_VERSION);
 
-    let (scrolls, cache) = load_with_cache(archive_path)?;
+    let (scrolls, cache) = load_with_cache(archive_path).map_err(anyhow::Error::msg)?;
 
     info!("✅ Loaded {} scroll(s).", scrolls.len());
     println!("✅ Loaded {} scroll(s).", scrolls.len());

--- a/scroll_core/src/parser.rs
+++ b/scroll_core/src/parser.rs
@@ -12,16 +12,17 @@ use crate::schema::{ScrollStatus, YamlMetadata};
 
 use crate::scroll::{Scroll, ScrollOrigin};
 use crate::validator::validate_scroll;
+use anyhow::{anyhow, Result};
 
-pub fn parse_scroll_from_file<P: AsRef<Path>>(path: P) -> Result<Scroll, String> {
-    let contents = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+pub fn parse_scroll_from_file<P: AsRef<Path>>(path: P) -> Result<Scroll> {
+    let contents = fs::read_to_string(&path).map_err(|e| anyhow!(e))?;
     parse_scroll(&contents)
 }
 
-pub fn parse_scroll(input: &str) -> Result<Scroll, String> {
+pub fn parse_scroll(input: &str) -> Result<Scroll> {
     let (yaml_str, markdown_body) = extract_yaml_and_markdown(input)?;
-    let yaml_metadata: YamlMetadata = serde_yaml::from_str(yaml_str).map_err(|e| e.to_string())?;
-    validate_scroll(&yaml_metadata)?;
+    let yaml_metadata: YamlMetadata = serde_yaml::from_str(yaml_str).map_err(|e| anyhow!(e))?;
+    validate_scroll(&yaml_metadata).map_err(|e| anyhow!(e))?;
 
     let emotion_signature = yaml_metadata.emotion_signature.clone();
     let scroll_type = yaml_metadata.scroll_type.clone();
@@ -47,10 +48,10 @@ pub fn parse_scroll(input: &str) -> Result<Scroll, String> {
     })
 }
 
-fn extract_yaml_and_markdown(input: &str) -> Result<(&str, &str), String> {
+fn extract_yaml_and_markdown(input: &str) -> Result<(&str, &str)> {
     let parts: Vec<&str> = input.splitn(3, "---").collect();
     if parts.len() < 3 {
-        return Err("Invalid format: missing YAML delimiters".into());
+        return Err(anyhow!("Invalid format: missing YAML delimiters"));
     }
     Ok((parts[1], parts[2]))
 }

--- a/scroll_core/src/scroll_writer.rs
+++ b/scroll_core/src/scroll_writer.rs
@@ -58,7 +58,7 @@ impl ScrollWriter {
 
     /// Applies patch and updates an existing scroll.
     pub fn update_scroll(_id: Uuid, updates: ScrollPatch, path: &Path) -> Result<(), String> {
-        let mut scroll = parse_scroll_from_file(path)?;
+        let mut scroll = parse_scroll_from_file(path).map_err(|e| e.to_string())?;
 
         if let Some(title) = updates.title {
             scroll.title = title.clone();

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -14,9 +14,7 @@ emotion_signature:
 # Markdown Body
 This is the body of the scroll.
 "#;
-    let result = parse_scroll(input);
-    assert!(result.is_ok());
-    let scroll = result.unwrap();
+    let scroll = parse_scroll(input).unwrap();
     assert_eq!(scroll.title, "Test Scroll");
     assert_eq!(scroll.status, ScrollStatus::Draft);
 }


### PR DESCRIPTION
## Summary
- convert parser and init helpers to `anyhow::Result`
- add simple `ChatDispatcher::new`
- update demo helper to use new result types and dispatcher
- adjust scroll writer and tests for new error type

## Testing
- `cargo test --all`
- `cargo clippy -- -D warnings` *(fails: many existing lints)*
- `cargo run -- --demo examples/multi_agent.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685449ab7c04833081d0187fa2bc5569