### PR TITLE
Implement simple semantic search

### DIFF
--- a/scroll_core/src/archive/mod.rs
+++ b/scroll_core/src/archive/mod.rs
@@ -17,3 +17,4 @@ pub mod archive_memory;
 pub mod initialize;
 pub mod mythic_heat;
 pub mod scroll_access_log;
+pub mod semantic_index;

--- a/scroll_core/src/archive/semantic_index.rs
+++ b/scroll_core/src/archive/semantic_index.rs
@@ -1,0 +1,56 @@
+use std::collections::HashSet;
+use uuid::Uuid;
+use log::info;
+
+use crate::scroll::Scroll;
+
+pub struct SemanticIndex {
+    vectors: Vec<(Uuid, HashSet<String>)>,
+}
+
+impl SemanticIndex {
+    pub fn build(scrolls: &[Scroll]) -> Self {
+        info!("Generating semantic vectors for {} scrolls", scrolls.len());
+        let vectors = scrolls
+            .iter()
+            .map(|s| {
+                let first_lines = s
+                    .markdown_body
+                    .lines()
+                    .take(3)
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let text = format!("{} {} {}", s.title, s.yaml_metadata.tags.join(" "), first_lines);
+                (s.id, tokenize(&text))
+            })
+            .collect();
+        info!("Vector generation complete");
+        Self { vectors }
+    }
+
+    pub fn query(&self, input: &str, k: usize) -> Vec<(Uuid, f32)> {
+        info!("Performing k-NN search for '{input}'");
+        let query_tokens = tokenize(input);
+        let mut scores: Vec<(Uuid, f32)> = self
+            .vectors
+            .iter()
+            .map(|(id, tokens)| (*id, jaccard_similarity(tokens, &query_tokens)))
+            .collect();
+        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        scores.into_iter().take(k).collect()
+    }
+}
+
+fn tokenize(text: &str) -> HashSet<String> {
+    text.to_lowercase()
+        .split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn jaccard_similarity(a: &HashSet<String>, b: &HashSet<String>) -> f32 {
+    let intersection = a.intersection(b).count() as f32;
+    let union = a.union(b).count() as f32;
+    if union == 0.0 { 0.0 } else { intersection / union }
+}

--- a/scroll_core/tests/semantic_search.rs
+++ b/scroll_core/tests/semantic_search.rs
@@ -1,0 +1,46 @@
+use logtest::Logger;
+use uuid::Uuid;
+use chrono::Utc;
+use scroll_core::archive::archive_memory::InMemoryArchive;
+use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
+
+fn make_scroll(title: &str, tags: &[&str], body: &str) -> Scroll {
+    Scroll {
+        id: Uuid::new_v4(),
+        title: title.into(),
+        scroll_type: ScrollType::Canon,
+        yaml_metadata: YamlMetadata {
+            title: title.into(),
+            scroll_type: ScrollType::Canon,
+            emotion_signature: EmotionSignature::neutral(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            last_modified: None,
+            file_path: None,
+        },
+        markdown_body: body.into(),
+        invocation_phrase: "Invoke".into(),
+        sigil: "🔮".into(),
+        status: ScrollStatus::Draft,
+        emotion_signature: EmotionSignature::neutral(),
+        linked_scrolls: vec![],
+        origin: ScrollOrigin {
+            created: Utc::now(),
+            authored_by: None,
+            last_modified: Utc::now(),
+        },
+    }
+}
+
+#[test]
+fn test_semantic_query_returns_relevant_scroll() {
+    let mut logger = Logger::start();
+    let s1 = make_scroll("Rust Guide", &["rust", "code"], "Learn Rust programming language.");
+    let s2 = make_scroll("Cooking Tips", &["cook"], "How to cook pasta.");
+    let mut archive = InMemoryArchive::new(vec![s1.clone(), s2.clone()]);
+    archive.build_semantic_index();
+    let results = archive.query_semantic("rust code tutorial", 1);
+    assert_eq!(results.first().unwrap().0.title, "Rust Guide");
+    let messages: Vec<String> = logger.map(|r| r.args().to_string()).collect();
+    assert!(messages.iter().any(|m| m.contains("Vector generation")));
+    assert!(messages.iter().any(|m| m.contains("k-NN search")));
+}


### PR DESCRIPTION
## Summary
- add `SemanticIndex` for token-based vector search
- extend `InMemoryArchive` with semantic index helpers
- implement `query_semantic` and logging
- test semantic search ordering and logging

## Testing
- `cargo test --no-run`
- `cargo test --test semantic_search -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68544df7b3fc8330855eb0a83c7ce7a8