### PR TITLE
Add vector memory metrics

### DIFF
--- a/docs/dashboards/vector_memory.json
+++ b/docs/dashboards/vector_memory.json
@@ -1,0 +1,20 @@
+{
+  "title": "Vector Memory",
+  "panels": [
+    {
+      "type": "heatmap",
+      "title": "Scroll Embed Time",
+      "targets": [{"expr": "rate(scroll_embed_time_seconds_bucket[5m])"}]
+    },
+    {
+      "type": "heatmap",
+      "title": "Index Update Time",
+      "targets": [{"expr": "rate(vector_index_update_time_seconds_bucket[5m])"}]
+    },
+    {
+      "type": "graph",
+      "title": "Index Memory",
+      "targets": [{"expr": "vector_index_memory_bytes_sum"}]
+    }
+  ]
+}

--- a/docs/modules/memory/metrics.md
+++ b/docs/modules/memory/metrics.md
@@ -1,0 +1,10 @@
+# Vector Memory Metrics
+
+The vector memory system exposes Prometheus metrics when Scroll Core is built with the `metrics` feature. Metrics are served on port `9898` by the built‑in exporter.
+
+### Histograms
+- `scroll_embed_time_seconds` – time spent generating a vector embedding for a single scroll.
+- `vector_index_update_time_seconds` – total time taken to rebuild the semantic index.
+- `vector_index_memory_bytes` – memory consumed by the index after an update.
+
+Run `curl localhost:9898/metrics` to view raw metrics or import `docs/dashboards/vector_memory.json` into Grafana for visualization.

--- a/scroll_core/src/trigger_loom/engine.rs
+++ b/scroll_core/src/trigger_loom/engine.rs
@@ -115,6 +115,6 @@ impl TriggerLoopEngine {
         info!("{}", summary.to_string());
 
         #[cfg(feature = "metrics")]
-        histogram!("tick_duration_ms", tick_start.elapsed().as_millis() as f64);
+        histogram!("tick_duration_ms").record(tick_start.elapsed().as_millis() as f64);
     }
 }

--- a/scroll_core/tests/vector_metrics.rs
+++ b/scroll_core/tests/vector_metrics.rs
@@ -1,0 +1,54 @@
+#[cfg(feature = "metrics")]
+use metrics_exporter_prometheus::PrometheusBuilder;
+#[cfg(feature = "metrics")]
+use scroll_core::archive::archive_memory::InMemoryArchive;
+#[cfg(feature = "metrics")]
+use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
+#[cfg(feature = "metrics")]
+use uuid::Uuid;
+
+#[cfg(feature = "metrics")]
+fn make_scroll(title: &str) -> Scroll {
+    Scroll {
+        id: Uuid::new_v4(),
+        title: title.into(),
+        scroll_type: ScrollType::Canon,
+        yaml_metadata: YamlMetadata {
+            title: title.into(),
+            scroll_type: ScrollType::Canon,
+            emotion_signature: EmotionSignature::default(),
+            tags: vec!["test".into()],
+            last_modified: None,
+            file_path: None,
+        },
+        markdown_body: "Body".into(),
+        invocation_phrase: String::new(),
+        sigil: String::new(),
+        status: ScrollStatus::Draft,
+        emotion_signature: EmotionSignature::default(),
+        linked_scrolls: vec![],
+        origin: ScrollOrigin {
+            created: chrono::Utc::now(),
+            authored_by: None,
+            last_modified: chrono::Utc::now(),
+        },
+    }
+}
+
+#[cfg(feature = "metrics")]
+#[test]
+fn test_vector_metrics_recorded() {
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("install recorder");
+
+    let scrolls = vec![make_scroll("one"), make_scroll("two")];
+    let mut archive = InMemoryArchive::new(scrolls);
+    archive.build_semantic_index();
+
+    handle.run_upkeep();
+    let body = handle.render();
+    assert!(body.contains("scroll_embed_time_seconds"));
+    assert!(body.contains("vector_index_update_time_seconds"));
+    assert!(body.contains("vector_index_memory_bytes"));
+}


### PR DESCRIPTION
## Summary
- instrument semantic index creation with Prometheus histograms
- record construct invocation metrics using latest metrics macros
- add Grafana dashboard config and docs for metrics
- test histogram emission when building semantic index

## Testing
- `cargo test`
- `cargo test -p scroll_core --features metrics --test vector_metrics`

------
https://chatgpt.com/codex/tasks/task_e_6854643c30c4833091d605c41ebda8ab