### PR TITLE
Fix chat CLI archive dir handling

### DIFF
--- a/docs/cli/chat.md
+++ b/docs/cli/chat.md
@@ -31,3 +31,7 @@ cargo run -- chat mythscribe --stream=false
 ```
 
 Chat history is stored in `scroll_core.db`.
+
+The archive directory defaults to `./scrolls`. Override this with the
+`SCROLL_CORE_ARCHIVE_DIR` environment variable. The chat CLI will create the
+directory (with a `.gitkeep` file) if it doesn't already exist.

--- a/scroll_core/src/archive/error.rs
+++ b/scroll_core/src/archive/error.rs
@@ -8,4 +8,6 @@ pub enum ArchiveError {
     MissingModel,
     #[error("embedding failed: {0}")]
     EmbeddingFailure(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/scroll_core/src/archive/initialize.rs
+++ b/scroll_core/src/archive/initialize.rs
@@ -1,12 +1,25 @@
 use std::path::Path;
+use std::fs;
 
 use crate::archive::archive_loader::load_scrolls_from_directory;
 use crate::archive::scroll_access_log::ScrollAccess;
+use crate::archive::error::ArchiveError;
 use crate::cache_manager::CacheManager;
 use crate::core::cost_manager::{
     ContextCost, CostDecision, CostProfile, InvocationCost, SystemCost,
 };
 use crate::scroll::Scroll;
+
+/// Ensures the archive directory exists, creating it and a `.gitkeep` file if
+/// needed.
+pub fn ensure_archive_dir(path: &Path) -> Result<(), ArchiveError> {
+    if !path.exists() {
+        fs::create_dir_all(path).map_err(ArchiveError::Io)?;
+        let keep = path.join(".gitkeep");
+        fs::write(keep, "").map_err(ArchiveError::Io)?;
+    }
+    Ok(())
+}
 
 /// Loads the archive from the given path and seeds a cache with the scrolls.
 /// The cache size is set to match the number of loaded scrolls.

--- a/scroll_core/src/cli/chat_db.rs
+++ b/scroll_core/src/cli/chat_db.rs
@@ -9,7 +9,8 @@ pub struct ChatDb {
 
 impl ChatDb {
     pub async fn open(path: &str) -> Result<Self, sqlx::Error> {
-        let pool = SqlitePool::connect(&format!("sqlite://{}", path)).await?;
+        let prefix = if path.starts_with('/') { "sqlite://" } else { "sqlite:" };
+        let pool = SqlitePool::connect(&format!("{}{}?mode=rwc", prefix, path)).await?;
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS scroll_sessions (id TEXT PRIMARY KEY, created_at REAL);",
         )

--- a/scroll_core/src/lib.rs
+++ b/scroll_core/src/lib.rs
@@ -57,7 +57,8 @@ pub fn initialize_scroll_core() -> Result<(Vec<Scroll>, CacheManager)> {
     use log::info;
     use std::path::Path;
 
-    let archive_path = Path::new("scrolls/");
+    let archive_dir = std::env::var("SCROLL_CORE_ARCHIVE_DIR").unwrap_or_else(|_| "scrolls".into());
+    let archive_path = Path::new(&archive_dir);
 
     info!("🌀 Scroll Core v{} initializing...", SCROLL_CORE_VERSION);
     println!("🌀 Scroll Core v{} initializing...", SCROLL_CORE_VERSION);
@@ -87,7 +88,8 @@ pub fn validate_scroll_environment() -> bool {
         return false;
     }
 
-    match fs::read_dir("scrolls/") {
+    let archive_dir = env::var("SCROLL_CORE_ARCHIVE_DIR").unwrap_or_else(|_| "scrolls".into());
+    match fs::read_dir(&archive_dir) {
         Ok(mut entries) => entries.next().is_some(),
         Err(_) => false,
     }

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -11,6 +11,7 @@ use scroll_core::chat::chat_dispatcher::ChatDispatcher;
 use scroll_core::cli::{chat::run_chat, chat_db::ChatDb};
 use scroll_core::{
     archive::archive_memory::InMemoryArchive,
+    archive::initialize::ensure_archive_dir,
     core::{
         construct_registry::ConstructRegistry,
         context_frame_engine::{ContextFrameEngine, ContextMode},
@@ -57,6 +58,9 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     if let Some(Commands::Chat { construct, stream }) = &cli.command {
+        let archive_dir = std::env::var("SCROLL_CORE_ARCHIVE_DIR")
+            .unwrap_or_else(|_| "scrolls".into());
+        ensure_archive_dir(Path::new(&archive_dir))?;
         let (scrolls, _cache) = initialize_scroll_core()?;
         let archive = InMemoryArchive::new(scrolls.clone());
         let engine = ContextFrameEngine::new(&archive, ContextMode::Narrow);

--- a/scroll_core/tests/chat_cli.rs
+++ b/scroll_core/tests/chat_cli.rs
@@ -1,19 +1,40 @@
 use assert_cmd::Command;
 use predicates::str::contains;
 use sqlx::SqlitePool;
+use tempfile::tempdir;
+use std::fs;
 
 #[tokio::test]
 async fn chat_cli_records() {
-    let _ = std::fs::remove_file("scroll_core.db");
+    let dir = tempdir().unwrap();
+    let archive = dir.path();
+    let db_path = archive.join("scroll_core.db");
+
+    fs::write(
+        archive.join("rust.md"),
+        "---\ntitle: Rust\nscroll_type: Canon\nemotion_signature:\n  tone: calm\n  emphasis: 0.5\n  resonance: gentle\ntags: [rust]\n---\nRust body.\n",
+    )
+    .unwrap();
+    fs::write(
+        archive.join("cook.md"),
+        "---\ntitle: Cook\nscroll_type: Canon\nemotion_signature:\n  tone: calm\n  emphasis: 0.5\n  resonance: gentle\ntags: [cook]\n---\nCook body.\n",
+    )
+    .unwrap();
+
     let mut cmd = Command::cargo_bin("scroll_core").unwrap();
     cmd.env("SCROLL_CORE_USE_MOCK", "1")
+        .env("SCROLL_CORE_ARCHIVE_DIR", archive)
+        .current_dir(archive)
         .args(["chat", "mythscribe", "--stream=false"])
         .write_stdin("ping\nexit\n")
         .assert()
         .success()
         .stdout(contains("pong"));
 
-    let pool = SqlitePool::connect_lazy("sqlite://scroll_core.db").unwrap();
+    let pool = SqlitePool::connect_lazy(
+        &format!("sqlite://{}", db_path.to_str().unwrap()),
+    )
+    .unwrap();
     let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM scroll_events")
         .fetch_one(&pool)
         .await


### PR DESCRIPTION
## Summary
- ensure archive directory exists when chat CLI runs
- allow overriding archive path with `SCROLL_CORE_ARCHIVE_DIR`
- adjust SQLite connection for cross-platform paths
- rework `chat_cli_records` integration test to use temp dirs
- document archive directory override and auto creation

## Testing
- `cargo test -p scroll_core --test chat_cli -q`
- `cargo test -p scroll_core --test ci_smoke -q`
- `cargo test -p scroll_core`

------
https://chatgpt.com/codex/tasks/task_e_685494e59688833085b28c12e224d726