### PR TITLE
Fix imports and compile checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
           components: rustfmt, clippy
       - name: cargo fmt
         run: cargo fmt -- --check
+      - name: cargo check
+        run: cargo check --all --tests
       - name: cargo clippy
         run: cargo clippy -- -D warnings
       - name: cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 ## [0.2.1] - 2025-06-19
 ### Removed
 - Removed episodic_writer module (superseded by stream_writer).
+
+## [0.2.2] - Unreleased
+### Changed
+- Renamed `context_frame_engine` module to `context_manager`.

--- a/fuzz/fuzz_targets/scroll_parser.rs
+++ b/fuzz/fuzz_targets/scroll_parser.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![warn(unused_imports)]
 use libfuzzer_sys::fuzz_target;
 use scroll_core::parser::parse_scroll;
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1,4 +1,5 @@
 // migration/src/lib.rs
+#![warn(unused_imports)]
 
 pub use sea_orm_migration::prelude::*;
 

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -1,4 +1,5 @@
 // migration/src/main.rs
+#![warn(unused_imports)]
 use migration::Migrator;
 use sea_orm_migration::cli::run_cli;
 

--- a/scroll_core/src/lib.rs
+++ b/scroll_core/src/lib.rs
@@ -1,6 +1,7 @@
 // ===============================
 // src/lib.rs
 // ===============================
+#![warn(unused_imports)]
 
 pub mod adk; // Agent Development Kit integration
 pub mod archive;

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -2,6 +2,8 @@
 //! Run normally:  `cargo run`
 //! Demo mode:     `cargo run -- --demo examples/multi_agent.yaml`
 
+#![warn(unused_imports)]
+
 use anyhow::Result;
 use std::path::Path;
 

--- a/tests/compile.rs
+++ b/tests/compile.rs
@@ -1,0 +1,2 @@
+#[test]
+fn compile() {}


### PR DESCRIPTION
## Summary
- warn on unused imports at crate roots
- run `cargo check --all --tests` in CI
- add compile smoke test
- document renaming context_frame_engine → context_manager

## Testing
- `cargo test --all`
- `cargo clippy --all -- -D warnings` *(fails: unused variables and clippy lints)*

------
https://chatgpt.com/codex/tasks/task_e_6854dec0a074833087d1f18cbae6d67b