### PR TITLE
Fix lockfile and migrate tests to ScrollBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +485,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.9",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +659,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -851,6 +887,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +935,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "env_logger"
@@ -906,13 +960,19 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -966,6 +1026,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "flume"
@@ -1164,7 +1244,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -1415,7 +1495,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1809,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989903b4c7abfa6827a8d1128ef42faf83f8969d429797c5431f236f2cae8b8b"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
@@ -1829,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39803e5c24a697c54492a76469034eee8247bd61825502e0410defc3e98eedf0"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1899,6 +1979,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +2007,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2290,6 +2396,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2655,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,7 +2840,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -2896,6 +3042,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "rustyline"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,6 +3089,7 @@ name = "scroll_core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "bytes",
  "cargo-fuzz",
@@ -2934,11 +3103,13 @@ dependencies = [
  "logtest",
  "metrics",
  "metrics-exporter-prometheus",
+ "predicates",
  "pulldown-cmark",
  "quickcheck",
  "quickcheck_macros",
  "regex",
  "reqwest",
+ "rustyline",
  "sea-orm 0.12.15",
  "sea-orm-migration",
  "serde",
@@ -3728,6 +3899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,6 +4258,12 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
@@ -4167,6 +4350,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"
@@ -4303,9 +4495,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4429,6 +4621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,11 +4653,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4472,6 +4689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,6 +4705,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4496,10 +4725,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4514,6 +4755,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4771,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4538,6 +4791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4548,6 +4807,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/scroll_core/src/scroll.rs
+++ b/scroll_core/src/scroll.rs
@@ -62,12 +62,71 @@ pub struct ScrollBuilder {
 }
 
 impl ScrollBuilder {
+    pub fn new(title: impl Into<String>) -> Self {
+        let title = title.into();
+        Self {
+            title: title.clone(),
+            scroll_type: ScrollType::Canon,
+            yaml_metadata: YamlMetadata {
+                title,
+                scroll_type: ScrollType::Canon,
+                emotion_signature: EmotionSignature::neutral(),
+                tags: vec![],
+                archetype: None,
+                quorum_required: false,
+                last_modified: None,
+                file_path: None,
+            },
+            tags: vec![],
+            archetype: None,
+            quorum_required: false,
+            markdown_body: String::new(),
+            invocation_phrase: String::new(),
+            sigil: String::new(),
+            emotion_signature: EmotionSignature::neutral(),
+            authored_by: None,
+        }
+    }
+
+    pub fn tags(mut self, tags: &[&str]) -> Self {
+        let collected: Vec<String> = tags.iter().map(|t| t.to_string()).collect();
+        self.tags = collected.clone();
+        self.yaml_metadata.tags = collected;
+        self
+    }
+
+    pub fn body(mut self, body: impl Into<String>) -> Self {
+        self.markdown_body = body.into();
+        self
+    }
+
+    pub fn invocation_phrase(mut self, phrase: impl Into<String>) -> Self {
+        self.invocation_phrase = phrase.into();
+        self
+    }
+
+    pub fn sigil(mut self, sigil: impl Into<String>) -> Self {
+        self.sigil = sigil.into();
+        self
+    }
+
+    pub fn last_modified(mut self, dt: DateTime<Utc>) -> Self {
+        self.yaml_metadata.last_modified = Some(dt);
+        self
+    }
+
     pub fn build(self) -> Scroll {
-        Scroll::new(self)
+        let mut scroll = Scroll::new(self);
+        scroll.status = ScrollStatus::Draft;
+        scroll
     }
 }
 
 impl Scroll {
+    pub fn builder(title: impl Into<String>) -> ScrollBuilder {
+        ScrollBuilder::new(title)
+    }
+
     pub fn new(params: ScrollBuilder) -> Self {
         let now = Utc::now();
         Scroll {

--- a/scroll_core/tests/archive_semantic_index.rs
+++ b/scroll_core/tests/archive_semantic_index.rs
@@ -1,44 +1,13 @@
-use chrono::Utc;
 use scroll_core::archive::archive_memory::InMemoryArchive;
 use scroll_core::archive::semantic_index::TokenEmbedder;
-use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
-use uuid::Uuid;
-
-fn make_scroll(title: &str) -> Scroll {
-    Scroll {
-        id: Uuid::new_v4(),
-        title: title.into(),
-        scroll_type: ScrollType::Canon,
-        yaml_metadata: YamlMetadata {
-            title: title.into(),
-            scroll_type: ScrollType::Canon,
-            emotion_signature: EmotionSignature::neutral(),
-            tags: vec![],
-            archetype: None,
-            quorum_required: false,
-            last_modified: None,
-            file_path: None,
-        },
-        tags: vec![],
-        archetype: None,
-        quorum_required: false,
-        markdown_body: "body".into(),
-        invocation_phrase: String::new(),
-        sigil: String::new(),
-        status: ScrollStatus::Draft,
-        emotion_signature: EmotionSignature::neutral(),
-        linked_scrolls: vec![],
-        origin: ScrollOrigin {
-            created: Utc::now(),
-            authored_by: None,
-            last_modified: Utc::now(),
-        },
-    }
-}
+use scroll_core::Scroll;
 
 #[test]
 fn builds_index_for_all_scrolls() {
-    let scrolls = vec![make_scroll("one"), make_scroll("two")];
+    let scrolls = vec![
+        Scroll::builder("one").body("body").build(),
+        Scroll::builder("two").body("body").build(),
+    ];
     let mut archive = InMemoryArchive::new(scrolls);
     archive.build_semantic_index(&TokenEmbedder).unwrap();
     assert_eq!(archive.semantic_index_len(), 2);

--- a/scroll_core/tests/context_engine_semantic.rs
+++ b/scroll_core/tests/context_engine_semantic.rs
@@ -1,56 +1,33 @@
-use chrono::Utc;
 use logtest::Logger;
 use scroll_core::archive::archive_memory::InMemoryArchive;
 use scroll_core::archive::semantic_index::TokenEmbedder;
 use scroll_core::core::context_frame_engine::{ContextFrameEngine, ContextMode};
-use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
-use uuid::Uuid;
-
-fn make_scroll(title: &str, tags: &[&str], body: &str) -> Scroll {
-    Scroll {
-        id: Uuid::new_v4(),
-        title: title.into(),
-        scroll_type: ScrollType::Canon,
-        yaml_metadata: YamlMetadata {
-            title: title.into(),
-            scroll_type: ScrollType::Canon,
-            emotion_signature: EmotionSignature::neutral(),
-            tags: tags.iter().map(|t| t.to_string()).collect(),
-            archetype: None,
-            quorum_required: false,
-            last_modified: None,
-            file_path: None,
-        },
-        tags: tags.iter().map(|t| t.to_string()).collect(),
-        archetype: None,
-        quorum_required: false,
-        markdown_body: body.into(),
-        invocation_phrase: "Invoke".into(),
-        sigil: "🔮".into(),
-        status: ScrollStatus::Draft,
-        emotion_signature: EmotionSignature::neutral(),
-        linked_scrolls: vec![],
-        origin: ScrollOrigin {
-            created: Utc::now(),
-            authored_by: None,
-            last_modified: Utc::now(),
-        },
-    }
-}
+use scroll_core::Scroll;
 
 #[test]
 fn test_context_engine_semantic_recall() {
     let logger = Logger::start();
-    let s1 = make_scroll("Rust Guide", &["rust", "code"], "Learn Rust.");
-    let s2 = make_scroll("Cooking Tips", &["cook"], "How to cook pasta.");
+    let s1 = Scroll::builder("Rust Guide")
+        .tags(["rust", "code"].as_ref())
+        .body("Learn Rust.")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .build();
+    let s2 = Scroll::builder("Cooking Tips")
+        .tags(["cook"].as_ref())
+        .body("How to cook pasta.")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .build();
     let mut archive = InMemoryArchive::new(vec![s1.clone(), s2]);
     archive.build_semantic_index(&TokenEmbedder).unwrap();
 
-    let trigger = make_scroll(
-        "Advanced Rust patterns",
-        &["programming"],
-        "Macros and traits.",
-    );
+    let trigger = Scroll::builder("Advanced Rust patterns")
+        .tags(["programming"].as_ref())
+        .body("Macros and traits.")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .build();
     let engine = ContextFrameEngine::new(&archive, ContextMode::Broad);
     let ctx = engine.build_context(&trigger);
     assert!(ctx.scrolls.iter().any(|s| s.title == "Rust Guide"));

--- a/scroll_core/tests/semantic_search.rs
+++ b/scroll_core/tests/semantic_search.rs
@@ -1,51 +1,23 @@
-use chrono::Utc;
 use logtest::Logger;
 use scroll_core::archive::archive_memory::InMemoryArchive;
 use scroll_core::archive::semantic_index::TokenEmbedder;
-use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
-use uuid::Uuid;
-
-fn make_scroll(title: &str, tags: &[&str], body: &str) -> Scroll {
-    Scroll {
-        id: Uuid::new_v4(),
-        title: title.into(),
-        scroll_type: ScrollType::Canon,
-        yaml_metadata: YamlMetadata {
-            title: title.into(),
-            scroll_type: ScrollType::Canon,
-            emotion_signature: EmotionSignature::neutral(),
-            tags: tags.iter().map(|t| t.to_string()).collect(),
-            archetype: None,
-            quorum_required: false,
-            last_modified: None,
-            file_path: None,
-        },
-        tags: tags.iter().map(|t| t.to_string()).collect(),
-        archetype: None,
-        quorum_required: false,
-        markdown_body: body.into(),
-        invocation_phrase: "Invoke".into(),
-        sigil: "🔮".into(),
-        status: ScrollStatus::Draft,
-        emotion_signature: EmotionSignature::neutral(),
-        linked_scrolls: vec![],
-        origin: ScrollOrigin {
-            created: Utc::now(),
-            authored_by: None,
-            last_modified: Utc::now(),
-        },
-    }
-}
+use scroll_core::Scroll;
 
 #[test]
 fn test_semantic_query_returns_relevant_scroll() {
     let logger = Logger::start();
-    let s1 = make_scroll(
-        "Rust Guide",
-        &["rust", "code"],
-        "Learn Rust programming language.",
-    );
-    let s2 = make_scroll("Cooking Tips", &["cook"], "How to cook pasta.");
+    let s1 = Scroll::builder("Rust Guide")
+        .tags(["rust", "code"].as_ref())
+        .body("Learn Rust programming language.")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .build();
+    let s2 = Scroll::builder("Cooking Tips")
+        .tags(["cook"].as_ref())
+        .body("How to cook pasta.")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .build();
     let mut archive = InMemoryArchive::new(vec![s1.clone(), s2.clone()]);
     archive.build_semantic_index(&TokenEmbedder).unwrap();
     let results = archive.query_semantic("rust code tutorial", 1);

--- a/scroll_core/tests/vector_metrics.rs
+++ b/scroll_core/tests/vector_metrics.rs
@@ -5,42 +5,7 @@ use scroll_core::archive::archive_memory::InMemoryArchive;
 #[cfg(feature = "metrics")]
 use scroll_core::archive::semantic_index::TokenEmbedder;
 #[cfg(feature = "metrics")]
-use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
-#[cfg(feature = "metrics")]
-use uuid::Uuid;
-
-#[cfg(feature = "metrics")]
-fn make_scroll(title: &str) -> Scroll {
-    Scroll {
-        id: Uuid::new_v4(),
-        title: title.into(),
-        scroll_type: ScrollType::Canon,
-        yaml_metadata: YamlMetadata {
-            title: title.into(),
-            scroll_type: ScrollType::Canon,
-            emotion_signature: EmotionSignature::default(),
-            tags: vec!["test".into()],
-            archetype: None,
-            quorum_required: false,
-            last_modified: None,
-            file_path: None,
-        },
-        tags: vec!["test".into()],
-        archetype: None,
-        quorum_required: false,
-        markdown_body: "Body".into(),
-        invocation_phrase: String::new(),
-        sigil: String::new(),
-        status: ScrollStatus::Draft,
-        emotion_signature: EmotionSignature::default(),
-        linked_scrolls: vec![],
-        origin: ScrollOrigin {
-            created: chrono::Utc::now(),
-            authored_by: None,
-            last_modified: chrono::Utc::now(),
-        },
-    }
-}
+use scroll_core::Scroll;
 
 #[cfg(feature = "metrics")]
 #[test]
@@ -49,7 +14,16 @@ fn test_vector_metrics_recorded() {
         .install_recorder()
         .expect("install recorder");
 
-    let scrolls = vec![make_scroll("one"), make_scroll("two")];
+    let scrolls = vec![
+        Scroll::builder("one")
+            .tags(["test"].as_ref())
+            .body("Body")
+            .build(),
+        Scroll::builder("two")
+            .tags(["test"].as_ref())
+            .body("Body")
+            .build(),
+    ];
     let mut archive = InMemoryArchive::new(scrolls);
     archive.build_semantic_index(&TokenEmbedder).unwrap();
 

--- a/tests/context_scorer_semantic.rs
+++ b/tests/context_scorer_semantic.rs
@@ -1,33 +1,8 @@
 use chrono::{Duration, Utc};
 use scroll_core::core::cost_manager::{ContextScorer, SemanticContextScorer};
 use scroll_core::invocation::invocation::{Invocation, InvocationMode, InvocationTier};
-use scroll_core::{EmotionSignature, Scroll, ScrollOrigin, ScrollStatus, ScrollType, YamlMetadata};
+use scroll_core::Scroll;
 use uuid::Uuid;
-
-fn make_scroll(days_ago: i64) -> Scroll {
-    let now = Utc::now() - Duration::days(days_ago);
-    Scroll {
-        id: Uuid::new_v4(),
-        title: "Test".into(),
-        scroll_type: ScrollType::Canon,
-        yaml_metadata: YamlMetadata {
-            title: "Test".into(),
-            scroll_type: ScrollType::Canon,
-            emotion_signature: EmotionSignature { tone: "neutral".into(), emphasis: 0.5, resonance: "flat".into(), intensity: Some(0.5) },
-            tags: vec![],
-            last_modified: Some(now),
-            file_path: None,
-        },
-        markdown_body: "Body".into(),
-        invocation_phrase: "Invoke".into(),
-        sigil: "🔮".into(),
-        status: ScrollStatus::Draft,
-        emotion_signature: EmotionSignature { tone: "neutral".into(), emphasis: 0.5, resonance: "flat".into(), intensity: Some(0.5) },
-        linked_scrolls: vec![],
-        origin: ScrollOrigin { created: now, authored_by: None, last_modified: now },
-    }
-}
-
 fn make_invocation() -> Invocation {
     Invocation {
         id: Uuid::new_v4(),
@@ -45,7 +20,13 @@ fn make_invocation() -> Invocation {
 fn test_semantic_score_influences() {
     let scorer = SemanticContextScorer;
     let inv = make_invocation();
-    let scroll = make_scroll(0);
+    let now = Utc::now();
+    let scroll = Scroll::builder("Test")
+        .body("Body")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .last_modified(now)
+        .build();
     let high = scorer.score(&inv, &[scroll.clone()], 0.9);
     let low = scorer.score(&inv, &[scroll], 0.1);
     assert!(high > low);
@@ -55,8 +36,18 @@ fn test_semantic_score_influences() {
 fn test_semantic_closer_ranked_higher() {
     let scorer = SemanticContextScorer;
     let inv = make_invocation();
-    let scroll_recent = make_scroll(0);
-    let scroll_old = make_scroll(10);
+    let scroll_recent = Scroll::builder("Test")
+        .body("Body")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .last_modified(Utc::now())
+        .build();
+    let scroll_old = Scroll::builder("Test")
+        .body("Body")
+        .invocation_phrase("Invoke")
+        .sigil("🔮")
+        .last_modified(Utc::now() - Duration::days(10))
+        .build();
     let score_recent = scorer.score(&inv, &[scroll_recent], 0.8);
     let score_old = scorer.score(&inv, &[scroll_old], 0.2);
     assert!(score_recent > score_old);


### PR DESCRIPTION
## Summary
- regenerate the Cargo.lock file
- add a builder API for `Scroll` with chainable methods
- update tests to construct scrolls with the new builder

## Testing
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_6855a23205c483309e6a7bea5cf84a66