### PR TITLE
Fix workspace release build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,5 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: cargo test
         run: cargo test --all
+      - name: cargo build release
+        run: cargo build --workspace --release

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,3 +19,7 @@ path = "fuzz_targets/scroll_parser.rs"
 test = false
 doc = false
 bench = false
+required-features = ["fuzzing"]
+
+[features]
+fuzzing = []

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -23,3 +23,6 @@ path = "src/main.rs"
 
 [dev-dependencies]
 trybuild = { version = "1", features = ["diff"] }
+
+[features]
+cli = []

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -1,5 +1,6 @@
 // migration/src/main.rs
 #![warn(unused_imports)]
+#[cfg(feature = "cli")]
 use migration::Migrator;
 #[cfg(feature = "cli")]
 use sea_orm_migration::cli::run_cli;


### PR DESCRIPTION
## Summary
- gate fuzz bin behind a `fuzzing` feature
- enable optional `cli` feature in migration crate
- call `Migrator` only when `cli` is enabled
- run release build in CI

## Testing
- `cargo build --workspace --release`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855ce6432f48330985b390a299116d9