### PR TITLE
Fix rustfmt CI failure; add --nocapture for clearer logs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,6 @@ jobs:
       - name: cargo deny
         run: cargo deny check
       - name: cargo test
-        run: cargo test --workspace
+        run: cargo test --workspace -- --nocapture
       - name: cargo build release
         run: cargo build --workspace --release

--- a/migration/tests/build_check.rs
+++ b/migration/tests/build_check.rs
@@ -3,4 +3,3 @@ fn build_migration() {
     let t = trybuild::TestCases::new();
     t.pass("tests/build/compile.rs");
 }
-


### PR DESCRIPTION
## Summary
- run `cargo fmt`
- show test output in CI via `--nocapture`

## Testing
- `cargo test --workspace -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6855ec0941408330b0222954ff14d031