### PR TITLE
Add Dev-Container bootstrap

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bookworm-slim
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git build-essential pkg-config \
+    sqlite3 libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN cargo install sea-orm-cli sqlx-cli cargo-udeps cargo-deny --locked
+RUN mkdir -p /workspaces
+WORKDIR /workspaces

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+    "name": "scroll_core",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceFolder": "/workspaces/scroll_core",
+    "onCreateCommand": "if [ ! -d /workspaces/scroll_core/.git ]; then git clone https://github.com/DieselRo/scroll_core /workspaces/scroll_core; fi",
+    "postCreateCommand": "bash /workspaces/scroll_core/.devcontainer/setup.sh && cargo test --workspace --locked --no-run"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if ! command -v sqlite3 >/dev/null; then
+  sudo apt-get update
+  sudo apt-get install -y sqlite3 libsqlite3-dev
+fi
+if ! command -v sea-orm-cli >/dev/null; then
+  cargo install sea-orm-cli sqlx-cli cargo-udeps cargo-deny --locked
+fi

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -1,0 +1,13 @@
+# Development Setup
+
+Quick start commands:
+
+```bash
+# VS Code
+gh repo clone DieselRo/scroll_core
+code scroll_core # VS Code prompts to "Reopen in Container"
+
+# Or Nix
+nix develop
+```
+


### PR DESCRIPTION
## Summary
- add `.devcontainer` with Dockerfile, setup script and config
- document quick setup instructions

## Testing
- `cargo test --workspace --no-run`

------
https://chatgpt.com/codex/tasks/task_e_685626ed4a80833098776a873f9b9013