### PR TITLE
ci: fix nightly toolchain mismatch for -Z flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,10 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
       - name: Determine Rust version
         id: rust-version
         run: echo "version=$(rustc --version)" >> "$GITHUB_OUTPUT"
@@ -47,9 +51,9 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Install cargo-udeps
-        run: cargo install cargo-udeps --locked
+        run: cargo +nightly install cargo-udeps --locked
       - name: cargo udeps
-        run: cargo udeps --workspace --all-targets
+        run: cargo +nightly udeps --workspace --all-targets
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: cargo deny


### PR DESCRIPTION
## Summary
- install the nightly toolchain alongside stable in CI
- run `cargo udeps` with the nightly toolchain

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68562ed993d88330966c8e70b01f16c9