### PR TITLE
ci: fix nightly toolchain mismatch for -Z flags

### DIFF
--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -11,3 +11,11 @@ code scroll_core # VS Code prompts to "Reopen in Container"
 nix develop
 ```
 
+Some CI checks use nightly-only flags. To run them locally, install the nightly
+toolchain and invoke commands with `cargo +nightly`, for example:
+
+```bash
+rustup toolchain install nightly
+cargo +nightly udeps --workspace --all-targets
+```
+


### PR DESCRIPTION
## Summary
- document nightly steps for cargo udeps

## Testing
- `cargo test --workspace -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6856375913b48330b751b9633d2a69f0