### PR TITLE
Add centralized tracing config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,6 +4066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,12 +4085,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = [ "scroll_core", "migration", "fuzz" ]
 resolver = "3"
+
+[workspace.dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,17 @@
+# Tracing
+
+Scroll Core emits structured logs via the `tracing` crate. The default format is JSON.
+
+Enable debug logs:
+
+```bash
+RUST_LOG=scroll_core=debug cargo run -- chat mythscribe --no-stream
+```
+
+Pipe logs into tools like `jq`:
+
+```bash
+RUST_LOG=scroll_core=info cargo run | jq .
+```
+
+Set `SCROLL_TRACE_FORMAT=pretty` or compile with the `compact_tracing` feature to use human friendly output.

--- a/scroll_core/Cargo.toml
+++ b/scroll_core/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { workspace = true }
 
 metrics = { version = "0.24", optional = true }
 metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false, features = ["http-listener"] }
@@ -81,6 +81,7 @@ predicates = "3"
 [features]
 metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
 cargo-deny = []
+compact_tracing = []
 
 
 

--- a/scroll_core/src/lib.rs
+++ b/scroll_core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod system;
 #[cfg(feature = "metrics")]
 pub mod telemetry;
 pub mod tools;
+pub mod tracing;
 pub mod trigger_loom;
 pub mod validator;
 
@@ -43,6 +44,7 @@ pub use scroll::{Scroll, ScrollOrigin};
 pub use validator::validate_scroll;
 
 pub use parser::{parse_scroll, parse_scroll_from_file};
+pub use tracing::{init_tracing, init_tracing_for_test};
 
 use anyhow::Result;
 

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -62,6 +62,8 @@ enum Commands {
 fn main() -> Result<()> {
     dotenv().ok();
 
+    scroll_core::init_tracing()?;
+
     #[cfg(feature = "metrics")]
     scroll_core::telemetry::init();
 

--- a/scroll_core/src/tracing.rs
+++ b/scroll_core/src/tracing.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use tracing_subscriber::{fmt, EnvFilter};
+
+/// Initialize global tracing subscriber for applications.
+pub fn init_tracing() -> Result<()> {
+    let filter = EnvFilter::from_default_env().add_directive("scroll_core=info".parse()?);
+    let format_env = std::env::var("SCROLL_TRACE_FORMAT")
+        .unwrap_or_default()
+        .to_lowercase();
+    if format_env == "pretty" || cfg!(feature = "compact_tracing") {
+        fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .without_time()
+            .init();
+    } else {
+        fmt()
+            .with_env_filter(filter)
+            .json()
+            .with_current_span(false)
+            .without_time()
+            .with_writer(std::io::stderr)
+            .init();
+    }
+    Ok(())
+}
+
+/// Initialize tracing for unit tests. Subsequent calls are ignored.
+pub fn init_tracing_for_test() -> Result<()> {
+    if tracing::dispatcher::has_been_set() {
+        return Ok(());
+    }
+    let filter = EnvFilter::from_default_env().add_directive("scroll_core=info".parse()?);
+    let format_env = std::env::var("SCROLL_TRACE_FORMAT")
+        .unwrap_or_default()
+        .to_lowercase();
+    if format_env == "pretty" || cfg!(feature = "compact_tracing") {
+        let _ = fmt()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .without_time()
+            .try_init();
+    } else {
+        let _ = fmt()
+            .with_env_filter(filter)
+            .json()
+            .with_current_span(false)
+            .without_time()
+            .with_writer(std::io::stderr)
+            .try_init();
+    }
+    Ok(())
+}

--- a/tests/tracing_init.rs
+++ b/tests/tracing_init.rs
@@ -1,0 +1,7 @@
+use tracing::dispatcher;
+
+#[test]
+fn tracing_initializes() {
+    scroll_core::init_tracing_for_test().expect("init tracing");
+    assert!(dispatcher::has_been_set());
+}


### PR DESCRIPTION
## Summary
- set up workspace-level `tracing-subscriber` with env-filter and JSON
- expose new tracing helpers and initialize in main
- provide compact_tracing feature flag
- document tracing usage
- add unit test for tracing setup

## Testing
- `cargo test --workspace -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6856c825b4c08330987ecadb1c046c74