### PR TITLE
Implement CLI color themes and history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +146,12 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -610,6 +625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,7 +766,7 @@ version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
 
@@ -876,6 +900,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +930,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -953,6 +989,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1870,6 +1917,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,7 +2768,7 @@ version = "1.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "borsh",
  "bytes",
  "num-traits",
@@ -2782,6 +2859,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "rustyline"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.27.1",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +2905,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "scroll_core"
 version = "0.2.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "assert_cmd",
  "async-trait",
@@ -2817,6 +2917,7 @@ dependencies = [
  "ctrlc",
  "dotenvy",
  "futures",
+ "home",
  "log",
  "logtest",
  "metrics",
@@ -2825,11 +2926,13 @@ dependencies = [
  "quickcheck",
  "regex",
  "reqwest",
+ "rustyline",
  "sea-orm",
  "serde",
  "serde_json",
  "serde_yaml",
  "sqlx",
+ "strip-ansi-escapes",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -3440,6 +3543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +4036,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,6 +4117,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/docs/cli_tips.md
+++ b/docs/cli_tips.md
@@ -1,0 +1,5 @@
+# CLI Tips
+
+- Disable the startup banner with `--no-banner`.
+- Switch color themes with `--theme dark` or `--theme light`.
+- Command history is saved to `~/.scroll_core_history`.

--- a/scroll_core/Cargo.toml
+++ b/scroll_core/Cargo.toml
@@ -17,6 +17,9 @@ log = "0.4"
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = { workspace = true }
+ansi_term = "0.12"
+rustyline = "13"
+home = "0.5"
 
 metrics = { version = "0.24", optional = true }
 metrics-exporter-prometheus = { version = "0.17", optional = true, default-features = false, features = ["http-listener"] }
@@ -70,6 +73,7 @@ quickcheck = "1"
 tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
+strip-ansi-escapes = "0.1"
 
 
 [features]

--- a/scroll_core/src/cli/chat.rs
+++ b/scroll_core/src/cli/chat.rs
@@ -8,7 +8,6 @@ use crate::Scroll;
 use anyhow::Result;
 use chrono::Utc;
 use ctrlc;
-use std::io::{self, BufRead};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -16,6 +15,10 @@ use std::sync::{
 use uuid::Uuid;
 
 use crate::cli::chat_db::ChatDb;
+use crate::cli::theme::Theme;
+use ansi_term::Colour;
+use home::home_dir;
+use rustyline::{error::ReadlineError, DefaultEditor};
 use tokio::runtime::Runtime;
 
 pub fn run_chat(
@@ -25,8 +28,14 @@ pub fn run_chat(
     target: &str,
     _stream: bool,
     db: &ChatDb,
+    theme: Theme,
+    show_banner: bool,
 ) -> Result<()> {
     let rt = Runtime::new()?;
+    if show_banner && std::env::var("SCROLL_CI").is_err() {
+        println!("{}", Colour::Purple.bold().paint("🔮 Scroll Core v0.2"));
+    }
+
     let mut session = ChatSession::new(Some(target.to_string()), None);
     let mut mood = EmotionalState::new(Vec::new(), 0.0, None);
     let session_id = rt.block_on(db.create_session())?;
@@ -38,16 +47,25 @@ pub fn run_chat(
         rflag.store(false, Ordering::SeqCst);
     })?;
 
-    let stdin = io::stdin();
+    let mut rl = DefaultEditor::new()?;
+    let hist_path = home_dir().map(|p| p.join(".scroll_core_history"));
+    if let Some(path) = &hist_path {
+        let _ = rl.load_history(path);
+    }
+
+    let prompt_user = theme.prompt_user.paint("You › ").to_string();
     while running.load(Ordering::SeqCst) {
-        let mut line = String::new();
-        if stdin.lock().read_line(&mut line)? == 0 {
-            break;
-        }
+        let readline = rl.readline(&prompt_user);
+        let line = match readline {
+            Ok(l) => l,
+            Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => break,
+            Err(e) => return Err(e.into()),
+        };
         let trimmed = line.trim();
         if trimmed.eq_ignore_ascii_case("exit") || trimmed.eq_ignore_ascii_case("quit") {
             break;
         }
+        let _ = rl.add_history_entry(trimmed);
 
         if let Err(e) = rt.block_on(db.log_event(&session_id, "user", trimmed)) {
             eprintln!(
@@ -73,6 +91,14 @@ pub fn run_chat(
                 "Failed to log event for session '{}', target '{}': {e}",
                 session_id, target
             );
+        }
+    }
+    if let Some(path) = &hist_path {
+        let _ = rl.save_history(path);
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            let lines: Vec<&str> = contents.lines().rev().take(500).collect();
+            let trimmed: String = lines.into_iter().rev().collect::<Vec<_>>().join("\n") + "\n";
+            let _ = std::fs::write(path, trimmed);
         }
     }
     Ok(())

--- a/scroll_core/src/cli/mod.rs
+++ b/scroll_core/src/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod chat;
 pub mod chat_db;
+pub mod theme;

--- a/scroll_core/src/cli/theme.rs
+++ b/scroll_core/src/cli/theme.rs
@@ -1,0 +1,45 @@
+use ansi_term::{Colour, Style};
+use clap::ValueEnum;
+use std::str::FromStr;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum ThemeKind {
+    Dark,
+    Light,
+}
+
+#[derive(Clone)]
+pub struct Theme {
+    pub prompt_user: Style,
+    pub prompt_agent: Style,
+}
+
+impl FromStr for ThemeKind {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "dark" => Ok(ThemeKind::Dark),
+            "light" => Ok(ThemeKind::Light),
+            other => Err(format!("unknown theme '{other}'")),
+        }
+    }
+}
+
+pub fn theme_parse(s: &str) -> Result<ThemeKind, String> {
+    s.parse()
+}
+
+impl ThemeKind {
+    pub fn styles(self) -> Theme {
+        match self {
+            ThemeKind::Dark => Theme {
+                prompt_user: Colour::Green.bold(),
+                prompt_agent: Colour::Blue.bold(),
+            },
+            ThemeKind::Light => Theme {
+                prompt_user: Colour::Purple.bold(),
+                prompt_agent: Colour::Cyan.bold(),
+            },
+        }
+    }
+}

--- a/scroll_core/tests/chat_cli.rs
+++ b/scroll_core/tests/chat_cli.rs
@@ -23,6 +23,7 @@ async fn chat_cli_records() {
 
     let mut cmd = Command::cargo_bin("scroll_core").unwrap();
     cmd.env("SCROLL_CORE_USE_MOCK", "1")
+        .env("SCROLL_CI", "1")
         .env("SCROLL_CORE_ARCHIVE_DIR", archive)
         .env("CHAT_DB_PATH", db_path.to_str().unwrap())
         .current_dir(archive)

--- a/scroll_core/tests/cli_theme.rs
+++ b/scroll_core/tests/cli_theme.rs
@@ -1,0 +1,8 @@
+use scroll_core::cli::theme::{theme_parse, ThemeKind};
+
+#[test]
+fn theme_parse_dark_light() {
+    assert_eq!(theme_parse("dark"), Ok(ThemeKind::Dark));
+    assert_eq!(theme_parse("light"), Ok(ThemeKind::Light));
+    assert!(theme_parse("mystic").is_err());
+}


### PR DESCRIPTION
## Summary
- add new Theme parsing module with dark and light styles
- support banner toggle, theme selection, and persistent history in `run_chat`
- wire theme options through CLI
- document CLI tips
- add tests for theme parsing

## Testing
- `cargo test --all --quiet`
- `cargo test --test ci_smoke -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68571832f89083308c39e39295b446c9