### PR TITLE
Add CLI quick-start docs and link check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,10 @@ jobs:
         run: |
           git config --global core.autocrlf false
           cargo xtask gen-map --check
+      - name: Install cargo-deadlinks
+        run: cargo install cargo-deadlinks --locked
+      - name: Check docs links
+        run: cargo deadlinks --dir docs
       - name: cargo test
         run: cargo test --workspace -- --nocapture
       - name: cargo build release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Scroll Core Agents
+
+Scroll Core houses the constructs and tooling that drive the Archive. It provides a CLI for conversations, utilities for validating scrolls, and infrastructure for new agents.
+
+## 🚪 Start Here
+
+| Doc | Description |
+|-----|-------------|
+| [docs/cli_quickstart.md](docs/cli_quickstart.md) | Launch the chat CLI |
+| [docs/dev_setup.md](docs/dev_setup.md) | Set up the dev container |
+| [docs/devops/ci_pipeline.md](docs/devops/ci_pipeline.md) | Project SOP & CI |
+| [docs/module_map.md](docs/module_map.md) | Architecture overview |
+
+## Constructs
+
+| Name | Purpose |
+|------|---------|
+| Mythscribe | Default LLM-based scribe construct |
+| Validator | Validate scroll metadata |
+| FileReader | Read scroll files into memory |
+| Mockscribe | Minimal test construct |
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation Overview
+
+This folder collects reference material for Scroll Core. The most relevant files for new contributors are linked below.
+
+- [CLI Quick-Start](cli_quickstart.md)
+- [Dev-Container Setup](dev_setup.md)
+- [CI Pipeline SOP](devops/ci_pipeline.md)
+- [Architecture Overview](module_map.md)

--- a/docs/cli_quickstart.md
+++ b/docs/cli_quickstart.md
@@ -1,0 +1,33 @@
+# CLI Quick-Start
+
+This guide assumes the repo has been cloned and dependencies are installed.
+
+## Build
+
+```bash
+cargo build --workspace
+```
+
+## Run Mythscribe
+
+```bash
+cargo run -- chat mythscribe --no-stream
+# Flags:
+#   --stream / --no-stream
+#   --theme dark|light
+#   --no-banner
+# Slash commands (after CLI-3):
+#   /help
+#   /scroll list
+#   /scroll open <id>
+```
+
+Press `Ctrl-S` during a chat session to toggle streaming after CLI-4.
+
+## Common Dev Tasks
+
+| Command | Purpose |
+|---------|---------|
+| `cargo test` | Run tests |
+| `cargo xtask gen-map` | Update module map |
+| `cargo fmt` | Format the code |


### PR DESCRIPTION
## Summary
- document CLI usage and common developer tasks
- provide an overview README for `docs`
- create an AGENTS index with quick links
- run markdown link checking in CI

## Testing
- `cargo run -- chat mythscribe --no-stream`
- `cargo deadlinks --dir docs`
- `cargo test`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_685745b2164c8330a3dcc3b975cde84d