### PR TITLE
feat: enable seaorm migration CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,6 +3108,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-orm-cli"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a4961b0d9098a9dc992d6e75fb761f9e5c442bb46746eeffa08e47b53759fce"
+dependencies = [
+ "chrono",
+ "clap",
+ "dotenvy",
+ "glob",
+ "regex",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "sea-orm-macros"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,7 +3144,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f58c3b1dcf6c137f08394f0228f9baf1574a2a799e93dc5da3cd9228bef9c5"
 dependencies = [
  "async-trait",
+ "clap",
+ "dotenvy",
  "sea-orm",
+ "sea-orm-cli",
  "sea-schema",
  "tracing",
  "tracing-subscriber",

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 tokio = { version = "1.38", features = ["full"] }
-sea-orm-migration = { version = "1.1", default-features = false, features = ["with-json"] }
+sea-orm-migration = { version = "1.1.12", features = ["cli"] }
 async-std = "1.12"
 dotenvy = "0.15"
 serde_json = "1.0"
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "migration"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [dev-dependencies]
 trybuild = { version = "1", features = ["diff"] }


### PR DESCRIPTION
## Summary
- enable the `cli` feature for sea-orm-migration
- gate the migration binary behind the `cli` feature

## Testing
- `cargo clippy --manifest-path migration/Cargo.toml -- -D warnings`
- `cargo test --manifest-path migration/Cargo.toml`
- `cargo build --bin migration --features cli`


------
https://chatgpt.com/codex/tasks/task_e_68586f59acfc83309762566ef32c1daa