### PR TITLE
chore: fix CI clippy issues

### DIFF
--- a/scroll_core/src/chat/chat_dispatcher.rs
+++ b/scroll_core/src/chat/chat_dispatcher.rs
@@ -63,7 +63,7 @@ impl ChatDispatcher {
         let mut args = vec!["slash"];
         args.extend(tokens.iter());
 
-        let mut app = Command::new("slash")
+        let app = Command::new("slash")
             .disable_help_subcommand(true)
             .subcommand(Command::new("help"))
             .subcommand(

--- a/scroll_core/src/cli/chat.rs
+++ b/scroll_core/src/cli/chat.rs
@@ -21,6 +21,7 @@ use home::home_dir;
 use rustyline::{error::ReadlineError, DefaultEditor};
 use tokio::runtime::Runtime;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_chat(
     manager: &InvocationManager,
     aelren: &AelrenHerald,


### PR DESCRIPTION
## Summary
- remove needless `mut` from chat CLI command builder
- allow clippy's `too_many_arguments` on `run_chat`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -p scroll_core --lib --bin scroll_core --bin test_db --bin run_tests -- -D warnings`
- `cargo test --workspace --exclude scroll_core`

------
https://chatgpt.com/codex/tasks/task_e_6858744ba8d483309e97329d863de075