### PR TITLE
chore: ignore udeps false positives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,16 @@ resolver = "3"
 
 [workspace.dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+[workspace.metadata.cargo-udeps.ignore]
+normal = [
+    "pulldown-cmark",
+    "rustyline",
+    "sea-orm-migration",
+    "tokio-stream",
+    "cargo-fuzz",
+    "quickcheck_macros",
+    "strip-ansi-escapes",
+    "trycmd",
+    "walkdir",
+]


### PR DESCRIPTION
## Summary
- suppress false positives from cargo-udeps

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68587e52dea483308fb32e9a2f3e6b48