### PR TITLE
feat: add async ledger service for invocation logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Run `cargo xtask gen-map` to regenerate `docs/module_map.md` after code changes.
 ## Alignment Docs
 
 Active plan, progress, and specs for aligning the runtime with the scrollbooks are tracked in `docs/alignment/`.
+
+## Ledger Service
+
+Invocation logs are written by a background ledger service. Events are
+sent over a bounded channel and flushed to the database asynchronously.
+Set `DATABASE_URL` to change the SQLite location used during local
+testing.

--- a/scroll_core/README.md
+++ b/scroll_core/README.md
@@ -10,3 +10,12 @@ Key entry points:
 - `chat/`: interactive chat and routing
 
 
+## Migration Notes (Ledger Service)
+
+Invocation logging now uses a long-lived asynchronous service. Each
+invocation sends a `LedgerEvent` over a bounded channel; the worker
+buffers events until the database connection is ready and then flushes
+them. This removes per-invocation thread spawns and prevents panics when
+the database has not been initialised.
+
+

--- a/scroll_core/src/invocation/invocation_manager.rs
+++ b/scroll_core/src/invocation/invocation_manager.rs
@@ -21,14 +21,17 @@ use tracing::info_span;
 pub struct InvocationManager {
     pub registry: ConstructRegistry,
     pub max_chain_depth: usize,
+    pub ledger: Option<crate::invocation::ledger_service::LedgerHandle>,
 }
 
 impl InvocationManager {
     pub fn new(registry: ConstructRegistry) -> Self {
-        Self {
-            registry,
-            max_chain_depth: 3,
-        }
+        Self { registry, max_chain_depth: 3, ledger: None }
+    }
+
+    pub fn with_ledger(mut self, handle: crate::invocation::ledger_service::LedgerHandle) -> Self {
+        self.ledger = Some(handle);
+        self
     }
 
     pub fn invoke_by_name(
@@ -93,20 +96,10 @@ impl InvocationManager {
 
         let result = self.registry.invoke(name, context);
 
-        // Opportunistic ledger write (ignore errors), fire-and-forget off-thread to avoid requiring a runtime
-        #[cfg(not(test))]
-        {
-            let inv = invocation.clone();
-            let cost_clone = cost.clone();
-            std::thread::spawn(move || {
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    rt.block_on(async {
-                        // Enrich decision string with routed construct
-                        let enriched = cost_clone.clone();
-                        if let CostDecision::Allow = enriched.decision {}
-                        let _ = crate::invocation::ledger::log_invocation_db(&inv, &enriched).await;
-                    });
-                }
+        if let Some(handle) = &self.ledger {
+            let _ = handle.try_log(crate::invocation::ledger_service::LedgerEvent {
+                invocation: invocation.clone(),
+                cost: cost.clone(),
             });
         }
 
@@ -140,14 +133,12 @@ impl InvocationManager {
                 timestamp: Utc::now(),
             };
             let cost = InvocationCost::default();
-            let _ = std::thread::spawn(move || {
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    rt.block_on(async {
-                        let _ =
-                            crate::invocation::ledger::log_invocation_db(&invocation, &cost).await;
-                    });
-                }
-            });
+            if let Some(handle) = &self.ledger {
+                let _ = handle.try_log(crate::invocation::ledger_service::LedgerEvent {
+                    invocation,
+                    cost,
+                });
+            }
         }
         herald.invoke_symbolically(scroll, &self.registry)
     }

--- a/scroll_core/src/invocation/ledger_service.rs
+++ b/scroll_core/src/invocation/ledger_service.rs
@@ -1,0 +1,119 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc::{self, error::TrySendError, Receiver, Sender};
+use tracing::warn;
+
+use crate::core::cost_manager::InvocationCost;
+use crate::invocation::ledger;
+use crate::invocation::types::Invocation;
+use crate::sessions::database;
+
+/// Event wrapping an invocation and its assessed cost.
+#[derive(Clone)]
+pub struct LedgerEvent {
+    pub invocation: Invocation,
+    pub cost: InvocationCost,
+}
+
+#[async_trait]
+pub trait LedgerWriter: Send + Sync + 'static {
+    async fn write(&self, event: &LedgerEvent) -> Result<(), sea_orm::DbErr>;
+}
+
+/// Default writer backed by SeaORM.
+pub struct SeaOrmLedgerWriter;
+
+#[async_trait]
+impl LedgerWriter for SeaOrmLedgerWriter {
+    async fn write(&self, event: &LedgerEvent) -> Result<(), sea_orm::DbErr> {
+        ledger::log_invocation_db(&event.invocation, &event.cost).await
+    }
+}
+
+/// Cloneable handle for sending ledger events.
+#[derive(Clone)]
+pub struct LedgerHandle {
+    sender: Sender<LedgerEvent>,
+}
+
+impl LedgerHandle {
+    pub fn try_log(&self, event: LedgerEvent) -> Result<(), TrySendError<LedgerEvent>> {
+        self.sender.try_send(event)
+    }
+}
+
+/// Background service running the worker task.
+pub struct LedgerService {
+    join_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl LedgerService {
+    /// Attempt to shut down the worker, waiting up to `timeout`.
+    /// Currently this simply joins the worker thread.
+    pub fn shutdown(mut self, _timeout: Duration) {
+        if let Some(handle) = self.join_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+async fn worker_loop<W: LedgerWriter>(
+    mut rx: Receiver<LedgerEvent>,
+    staging_capacity: usize,
+    writer: W,
+) {
+    let mut staging: VecDeque<LedgerEvent> = VecDeque::new();
+    while let Some(event) = rx.recv().await {
+        if !database::is_initialized() {
+            if staging_capacity > 0 {
+                staging.push_back(event);
+                if staging.len() > staging_capacity {
+                    staging.pop_front();
+                }
+            }
+            continue;
+        }
+
+        while let Some(staged) = staging.pop_front() {
+            if let Err(e) = writer.write(&staged).await {
+                warn!("ledger write failed: {e}");
+            }
+        }
+
+        if let Err(e) = writer.write(&event).await {
+            warn!("ledger write failed: {e}");
+        }
+    }
+
+    if database::is_initialized() {
+        while let Some(staged) = staging.pop_front() {
+            if let Err(e) = writer.write(&staged).await {
+                warn!("ledger write failed: {e}");
+            }
+        }
+    }
+}
+
+/// Starts the ledger service with a bounded channel and optional staging buffer.
+pub fn start(
+    chan_capacity: usize,
+    staging_capacity: usize,
+) -> (LedgerHandle, LedgerService) {
+    let (tx, rx) = mpsc::channel(chan_capacity);
+    let handle = LedgerHandle { sender: tx.clone() };
+
+    let join_handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("ledger runtime");
+        rt.block_on(worker_loop(rx, staging_capacity, SeaOrmLedgerWriter));
+    });
+
+    (
+        handle,
+        LedgerService {
+            join_handle: Some(join_handle),
+        },
+    )
+}
+

--- a/scroll_core/src/invocation/mod.rs
+++ b/scroll_core/src/invocation/mod.rs
@@ -10,6 +10,7 @@ pub mod constructs;
 pub mod llm;
 pub mod invocation_manager;
 pub mod ledger;
+pub mod ledger_service;
 pub mod named_construct;
 pub mod types;
 

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -31,6 +31,7 @@ use scroll_core::{
     teardown_scroll_core,
     trigger_loom::emotional_state::EmotionalState,
 };
+use std::time::Duration;
 
 /// CLI flags recognised by Scroll Core.
 #[derive(Parser)]
@@ -117,9 +118,18 @@ fn main() -> Result<()> {
         let db_url = std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "sqlite://scroll_core.db?mode=rwc".into());
         let rt = tokio::runtime::Runtime::new()?;
-        let _ = rt.block_on(scroll_core::sessions::database::init_sqlite_connection(
-            &db_url,
-        ));
+        let _ = rt.block_on(async {
+            if scroll_core::sessions::database::init_sqlite_connection(&db_url)
+                .await
+                .is_ok()
+            {
+                let _ = migration::Migrator::up(
+                    scroll_core::sessions::database::get_db_connection(),
+                    None,
+                )
+                .await;
+            }
+        });
         let mut archive = InMemoryArchive::new(scrolls.clone());
         // Build semantic index for context modes that rely on it
         {
@@ -141,7 +151,9 @@ fn main() -> Result<()> {
         }
         // Optional: attach a pulse-sensitive construct to bus later (Phase 6)
 
-        let manager = InvocationManager::new(registry);
+        let (ledger_handle, ledger_service) =
+            scroll_core::invocation::ledger_service::start(64, 256);
+        let manager = InvocationManager::new(registry).with_ledger(ledger_handle);
         let aelren = AelrenHerald::new(engine, vec![construct.clone()]);
         let stream_enabled = *stream && !*no_stream;
         let theme_struct = theme.styles();
@@ -154,6 +166,8 @@ fn main() -> Result<()> {
             theme_struct,
             !*no_banner,
         )?;
+        drop(manager);
+        ledger_service.shutdown(Duration::from_millis(250));
         teardown_scroll_core();
         return Ok(());
     }
@@ -290,11 +304,15 @@ fn main() -> Result<()> {
                     }
                 }
             }
-
-            let manager = InvocationManager::new(registry);
+            let (ledger_handle, ledger_service) =
+                scroll_core::invocation::ledger_service::start(64, 256);
+            let manager = InvocationManager::new(registry).with_ledger(ledger_handle);
             let aelren = AelrenHerald::new(engine, vec!["mythscribe".into()]);
 
             scroll_core::system::cli_orchestrator::run_cli(&manager, &aelren, &scrolls);
+
+            drop(manager);
+            ledger_service.shutdown(Duration::from_millis(250));
         }
         Err(e) => eprintln!("❌ Initialization failed: {e}"),
     }

--- a/scroll_core/tests/chat_e2e.rs
+++ b/scroll_core/tests/chat_e2e.rs
@@ -7,7 +7,9 @@ use scroll_core::chat::chat_session::ChatSession;
 use scroll_core::core::construct_registry::ConstructRegistry;
 use scroll_core::core::context_frame_engine::{ContextFrameEngine, ContextMode};
 use scroll_core::invocation::aelren::AelrenHerald;
-use scroll_core::invocation::constructs::openai_construct::{Mythscribe, OpenAIClient};
+use scroll_core::invocation::constructs::openai_construct::Mythscribe;
+use scroll_core::invocation::llm::{openai::OpenAIClient, LLMClient};
+use std::sync::Arc;
 use scroll_core::invocation::invocation_manager::InvocationManager;
 use scroll_core::trigger_loom::emotional_state::EmotionalState;
 
@@ -38,13 +40,14 @@ async fn test_chat_dispatcher_records_access() {
     )));
 
     let mut registry = ConstructRegistry::new();
-    let client = OpenAIClient {
-        api_key: "test".into(),
-        model: "gpt-4o".into(),
-        endpoint: format!("{}/v1/chat/completions", server.uri()),
-        max_tokens: 50,
-    };
-    registry.insert("mythscribe", Mythscribe::new(client, "System".into()));
+    std::env::set_var("OPENAI_API_KEY", "test");
+    std::env::set_var("SC_LLM_MODEL", "gpt-4o");
+    std::env::set_var(
+        "SC_LLM_ENDPOINT",
+        format!("{}/v1/chat/completions", server.uri()),
+    );
+    let client: Arc<dyn LLMClient + Send + Sync> = Arc::new(OpenAIClient::new_from_env().unwrap());
+    registry.insert("mythscribe", Mythscribe::new(client.clone(), "System".into()));
     let manager = Box::leak(Box::new(InvocationManager::new(registry)));
 
     let scrolls_thread = scrolls.clone();

--- a/scroll_core/tests/ledger_service_tests.rs
+++ b/scroll_core/tests/ledger_service_tests.rs
@@ -1,0 +1,90 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use migration::{Migrator, MigratorTrait};
+use sea_orm::{EntityTrait, PaginatorTrait};
+use tempfile::NamedTempFile;
+use scroll_core::core::cost_manager::InvocationCost;
+use scroll_core::invocation::ledger::Entity as LedgerEntity;
+use scroll_core::invocation::ledger_service::{start, LedgerEvent};
+use scroll_core::invocation::types::{Invocation, InvocationMode, InvocationTier};
+use scroll_core::sessions::database::{get_db_connection, init_sqlite_connection};
+use uuid::Uuid;
+
+fn sample_event() -> LedgerEvent {
+    LedgerEvent {
+        invocation: Invocation {
+            id: Uuid::new_v4(),
+            phrase: "p".into(),
+            invoker: "i".into(),
+            invoked: "j".into(),
+            tier: InvocationTier::Calling,
+            mode: InvocationMode::Read,
+            resonance_required: false,
+            timestamp: Utc::now(),
+        },
+        cost: InvocationCost::default(),
+    }
+}
+
+#[test]
+fn ledger_service_behaviour() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let tmp = NamedTempFile::new().unwrap();
+    let db_url = format!("sqlite://{}", tmp.path().to_string_lossy());
+
+    // start service before DB ready, send events
+    let (handle, service) = start(8, 5);
+    for _ in 0..10 {
+        let _ = handle.try_log(sample_event());
+    }
+    rt.block_on(async {
+        init_sqlite_connection(&db_url).await.unwrap();
+        Migrator::up(get_db_connection(), None).await.unwrap();
+    });
+    drop(handle);
+    service.shutdown(Duration::from_secs(1));
+    rt.block_on(async {
+        let count = LedgerEntity::find()
+            .count(get_db_connection())
+            .await
+            .unwrap();
+        assert_eq!(count, 5);
+        let _ = LedgerEntity::delete_many().exec(get_db_connection()).await.unwrap();
+    });
+
+    // backpressure with small channel
+    let (handle, service) = start(2, 0);
+    let mut accepted = 0;
+    for _ in 0..100 {
+        if handle.try_log(sample_event()).is_ok() {
+            accepted += 1;
+        }
+    }
+    drop(handle);
+    service.shutdown(Duration::from_secs(1));
+    rt.block_on(async {
+        let count = LedgerEntity::find()
+            .count(get_db_connection())
+            .await
+            .unwrap();
+        assert_eq!(count, accepted);
+        assert!(accepted < 100);
+        let _ = LedgerEntity::delete_many().exec(get_db_connection()).await.unwrap();
+    });
+
+    // happy path with DB ready
+    let (handle, service) = start(64, 10);
+    for _ in 0..20 {
+        let _ = handle.try_log(sample_event());
+    }
+    drop(handle);
+    service.shutdown(Duration::from_secs(1));
+    rt.block_on(async {
+        let count = LedgerEntity::find()
+            .count(get_db_connection())
+            .await
+            .unwrap();
+        assert_eq!(count, 20);
+    });
+}


### PR DESCRIPTION
## Summary
- introduce long-lived async ledger service with bounded channel and staging buffer
- route invocation logging through a `LedgerHandle` instead of spawning per-call runtimes
- start and shut down the ledger service in CLI paths; update tests and docs

## Testing
- `cargo test --test ledger_service_tests -- --nocapture`
- `cargo test --test chat_e2e -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68978c138a98833089fbc036f42ab396