### PR TITLE
feat: introduce async ledger service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Run `cargo xtask gen-map` to regenerate `docs/module_map.md` after code changes.
 ## Alignment Docs
 
 Active plan, progress, and specs for aligning the runtime with the scrollbooks are tracked in `docs/alignment/`.
+
+## Ledger & Database
+
+The runtime logs invocations to SQLite. Set `DATABASE_URL` to point at a writable
+location (default `sqlite://scroll_core.db?mode=rwc`). During local development
+you can run `cargo test ledger_service_tests -- --nocapture` to verify the
+ledger service buffers and flushes as expected.

--- a/scroll_core/README.md
+++ b/scroll_core/README.md
@@ -9,4 +9,13 @@ Key entry points:
 - `invocation/`: constructs and invocation manager
 - `chat/`: interactive chat and routing
 
+## Migration Notes (Ledger Service)
 
+Invocation logging now uses a long-lived async service rather than per-call
+threads. Events are sent over a bounded channel and written once the database is
+ready. Under load, excess events are dropped predictably. To verify the ledger:
+
+1. Set `DATABASE_URL` (defaults to `sqlite://scroll_core.db?mode=rwc`).
+2. Run the CLI or chat; invocations will accumulate in the `invocation_ledger`
+   table.
+3. To roll back, omit starting the service and ledger writes become no-ops.

--- a/scroll_core/src/invocation/invocation_manager.rs
+++ b/scroll_core/src/invocation/invocation_manager.rs
@@ -12,6 +12,8 @@ use crate::core::ConstructRegistry;
 use crate::invocation::aelren::AelrenHerald;
 use crate::invocation::types::{Invocation, InvocationMode, InvocationTier};
 use crate::trigger_loom::ambient;
+
+use crate::invocation::ledger_service::{LedgerEvent, LedgerHandle};
 use chrono::Utc;
 use uuid::Uuid;
 
@@ -21,6 +23,7 @@ use tracing::info_span;
 pub struct InvocationManager {
     pub registry: ConstructRegistry,
     pub max_chain_depth: usize,
+    ledger: Option<LedgerHandle>,
 }
 
 impl InvocationManager {
@@ -28,7 +31,13 @@ impl InvocationManager {
         Self {
             registry,
             max_chain_depth: 3,
+            ledger: None,
         }
+    }
+
+    pub fn with_ledger(mut self, handle: LedgerHandle) -> Self {
+        self.ledger = Some(handle);
+        self
     }
 
     pub fn invoke_by_name(
@@ -93,20 +102,10 @@ impl InvocationManager {
 
         let result = self.registry.invoke(name, context);
 
-        // Opportunistic ledger write (ignore errors), fire-and-forget off-thread to avoid requiring a runtime
-        #[cfg(not(test))]
-        {
-            let inv = invocation.clone();
-            let cost_clone = cost.clone();
-            std::thread::spawn(move || {
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    rt.block_on(async {
-                        // Enrich decision string with routed construct
-                        let enriched = cost_clone.clone();
-                        if let CostDecision::Allow = enriched.decision {}
-                        let _ = crate::invocation::ledger::log_invocation_db(&inv, &enriched).await;
-                    });
-                }
+        if let Some(handle) = &self.ledger {
+            let _ = handle.try_log(LedgerEvent {
+                invocation: invocation.clone(),
+                cost: cost.clone(),
             });
         }
 
@@ -140,14 +139,9 @@ impl InvocationManager {
                 timestamp: Utc::now(),
             };
             let cost = InvocationCost::default();
-            let _ = std::thread::spawn(move || {
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    rt.block_on(async {
-                        let _ =
-                            crate::invocation::ledger::log_invocation_db(&invocation, &cost).await;
-                    });
-                }
-            });
+            if let Some(handle) = &self.ledger {
+                let _ = handle.try_log(LedgerEvent { invocation, cost });
+            }
         }
         herald.invoke_symbolically(scroll, &self.registry)
     }

--- a/scroll_core/src/invocation/ledger_service.rs
+++ b/scroll_core/src/invocation/ledger_service.rs
@@ -1,0 +1,103 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::{self, error::TrySendError, Receiver, Sender};
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+use crate::core::cost_manager::InvocationCost;
+use crate::invocation::ledger;
+use crate::invocation::types::Invocation;
+use crate::sessions::database;
+
+/// Event containing the data needed for a ledger write.
+pub struct LedgerEvent {
+    pub invocation: Invocation,
+    pub cost: InvocationCost,
+}
+
+#[async_trait]
+pub trait LedgerWriter: Send + Sync + 'static {
+    async fn write(&self, event: LedgerEvent);
+}
+
+pub struct SeaOrmLedgerWriter;
+
+#[async_trait]
+impl LedgerWriter for SeaOrmLedgerWriter {
+    async fn write(&self, event: LedgerEvent) {
+        if let Err(e) = ledger::log_invocation_db(&event.invocation, &event.cost).await {
+            warn!("ledger write error: {e}");
+        }
+    }
+}
+
+/// Cloneable handle exposed to call sites for non-blocking logging.
+#[derive(Clone)]
+pub struct LedgerHandle {
+    sender: Sender<LedgerEvent>,
+}
+
+impl LedgerHandle {
+    pub fn try_log(&self, event: LedgerEvent) -> Result<(), TrySendError<LedgerEvent>> {
+        self.sender.try_send(event)
+    }
+}
+
+pub struct LedgerService {
+    runtime: Runtime,
+    worker: JoinHandle<()>,
+}
+
+impl LedgerService {
+    pub fn shutdown(self, timeout: Duration) {
+        self.runtime.block_on(async {
+            let _ = tokio::time::timeout(timeout, self.worker).await;
+        });
+        self.runtime.shutdown_timeout(timeout);
+    }
+}
+
+pub fn start(chan_capacity: usize, staging_capacity: usize) -> (LedgerHandle, LedgerService) {
+    let (tx, rx) = mpsc::channel(chan_capacity);
+    let runtime = Runtime::new().expect("failed to create runtime");
+    let worker = runtime.spawn(worker(rx, staging_capacity, SeaOrmLedgerWriter));
+    (
+        LedgerHandle { sender: tx },
+        LedgerService { runtime, worker },
+    )
+}
+
+async fn worker<W>(mut rx: Receiver<LedgerEvent>, staging_capacity: usize, writer: W)
+where
+    W: LedgerWriter,
+{
+    let mut staging = VecDeque::new();
+    while let Some(event) = rx.recv().await {
+        if !database::is_initialized() {
+            if staging.len() >= staging_capacity {
+                staging.pop_front();
+            }
+            staging.push_back(event);
+            continue;
+        }
+
+        flush_staging(&mut staging, &writer).await;
+        writer.write(event).await;
+    }
+
+    if database::is_initialized() {
+        flush_staging(&mut staging, &writer).await;
+    }
+}
+
+async fn flush_staging<W>(staging: &mut VecDeque<LedgerEvent>, writer: &W)
+where
+    W: LedgerWriter,
+{
+    while let Some(ev) = staging.pop_front() {
+        writer.write(ev).await;
+    }
+}

--- a/scroll_core/src/invocation/mod.rs
+++ b/scroll_core/src/invocation/mod.rs
@@ -7,9 +7,10 @@
 
 pub mod aelren;
 pub mod constructs;
-pub mod llm;
 pub mod invocation_manager;
 pub mod ledger;
+pub mod ledger_service;
+pub mod llm;
 pub mod named_construct;
 pub mod types;
 

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -22,10 +22,8 @@ use scroll_core::{
     },
     initialize_scroll_core,
     invocation::{
-        aelren::AelrenHerald,
-        constructs::openai_construct::Mythscribe,
-        invocation_manager::InvocationManager,
-        llm::factory,
+        aelren::AelrenHerald, constructs::openai_construct::Mythscribe,
+        invocation_manager::InvocationManager, ledger_service, llm::factory,
     },
     parser::parse_scroll,
     teardown_scroll_core,
@@ -113,13 +111,17 @@ fn main() -> Result<()> {
             std::env::var("SCROLL_CORE_ARCHIVE_DIR").unwrap_or_else(|_| "scrolls".into());
         ensure_archive_dir(Path::new(&archive_dir))?;
         let (scrolls, _cache) = initialize_scroll_core()?;
-        // Initialize database connection for session logging
+        // Initialize database connection and migrations for session logging
         let db_url = std::env::var("DATABASE_URL")
             .unwrap_or_else(|_| "sqlite://scroll_core.db?mode=rwc".into());
         let rt = tokio::runtime::Runtime::new()?;
-        let _ = rt.block_on(scroll_core::sessions::database::init_sqlite_connection(
-            &db_url,
-        ));
+        rt.block_on(async {
+            let _ = scroll_core::sessions::database::init_sqlite_connection(&db_url).await;
+            let _ =
+                migration::Migrator::up(scroll_core::sessions::database::get_db_connection(), None)
+                    .await;
+        });
+        let (ledger_handle, ledger_service) = ledger_service::start(64, 256);
         let mut archive = InMemoryArchive::new(scrolls.clone());
         // Build semantic index for context modes that rely on it
         {
@@ -136,12 +138,15 @@ fn main() -> Result<()> {
             );
         } else {
             let client = factory::from_env().map_err(|e| anyhow::anyhow!(e.to_string()))?;
-            let mythscribe = Mythscribe::new(client, "You are Mythscribe, the poetic analyst of sacred scrolls.".into());
+            let mythscribe = Mythscribe::new(
+                client,
+                "You are Mythscribe, the poetic analyst of sacred scrolls.".into(),
+            );
             registry.insert("mythscribe", mythscribe);
         }
         // Optional: attach a pulse-sensitive construct to bus later (Phase 6)
 
-        let manager = InvocationManager::new(registry);
+        let manager = InvocationManager::new(registry).with_ledger(ledger_handle);
         let aelren = AelrenHerald::new(engine, vec![construct.clone()]);
         let stream_enabled = *stream && !*no_stream;
         let theme_struct = theme.styles();
@@ -154,6 +159,8 @@ fn main() -> Result<()> {
             theme_struct,
             !*no_banner,
         )?;
+        drop(manager);
+        ledger_service.shutdown(std::time::Duration::from_millis(250));
         teardown_scroll_core();
         return Ok(());
     }
@@ -266,35 +273,32 @@ fn main() -> Result<()> {
             // Seed construct registry
             let mut registry = ConstructRegistry::new();
             let client = factory::from_env().map_err(|e| anyhow::anyhow!(e.to_string()))?;
-            let mythscribe = Mythscribe::new(client, "You are Mythscribe, the poetic analyst of sacred scrolls.".into());
+            let mythscribe = Mythscribe::new(
+                client,
+                "You are Mythscribe, the poetic analyst of sacred scrolls.".into(),
+            );
             registry.insert("mythscribe", mythscribe);
 
             // Ensure DB connection and migrations for CLI ledger/session logging
-            {
-                let db_url = std::env::var("DATABASE_URL")
-                    .unwrap_or_else(|_| "sqlite://scroll_core.db?mode=rwc".into());
-                if !scroll_core::sessions::database::is_initialized() {
-                    if let Ok(rt) = tokio::runtime::Runtime::new() {
-                        rt.block_on(async {
-                            if scroll_core::sessions::database::init_sqlite_connection(&db_url)
-                                .await
-                                .is_ok()
-                            {
-                                let _ = migration::Migrator::up(
-                                    scroll_core::sessions::database::get_db_connection(),
-                                    None,
-                                )
-                                .await;
-                            }
-                        });
-                    }
-                }
-            }
+            let db_url = std::env::var("DATABASE_URL")
+                .unwrap_or_else(|_| "sqlite://scroll_core.db?mode=rwc".into());
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(async {
+                let _ = scroll_core::sessions::database::init_sqlite_connection(&db_url).await;
+                let _ = migration::Migrator::up(
+                    scroll_core::sessions::database::get_db_connection(),
+                    None,
+                )
+                .await;
+            });
+            let (ledger_handle, ledger_service) = ledger_service::start(64, 256);
 
-            let manager = InvocationManager::new(registry);
+            let manager = InvocationManager::new(registry).with_ledger(ledger_handle);
             let aelren = AelrenHerald::new(engine, vec!["mythscribe".into()]);
 
             scroll_core::system::cli_orchestrator::run_cli(&manager, &aelren, &scrolls);
+            drop(manager);
+            ledger_service.shutdown(std::time::Duration::from_millis(250));
         }
         Err(e) => eprintln!("❌ Initialization failed: {e}"),
     }
@@ -326,7 +330,10 @@ fn run_demo<P: AsRef<std::path::Path>>(path: P) -> Result<()> {
     let engine = ContextFrameEngine::new(&archive, ContextMode::Narrow);
     let mut reg = ConstructRegistry::new();
     let client = factory::from_env().map_err(|e| anyhow::anyhow!(e.to_string()))?;
-    let myth = Mythscribe::new(client, "You are Mythscribe, the poetic analyst of sacred scrolls.".into());
+    let myth = Mythscribe::new(
+        client,
+        "You are Mythscribe, the poetic analyst of sacred scrolls.".into(),
+    );
     reg.insert("mythscribe", myth);
     let manager = InvocationManager::new(reg);
 

--- a/scroll_core/tests/a_ledger_service_tests.rs
+++ b/scroll_core/tests/a_ledger_service_tests.rs
@@ -1,0 +1,75 @@
+use std::time::Duration;
+
+use migration::{Migrator, MigratorTrait};
+use sea_orm::{EntityTrait, PaginatorTrait};
+use scroll_core::core::cost_manager::InvocationCost;
+use scroll_core::invocation::ledger::Entity as LedgerEntity;
+use scroll_core::invocation::ledger_service::{self, LedgerEvent};
+use scroll_core::invocation::types::{Invocation, InvocationMode, InvocationTier};
+use scroll_core::sessions::database;
+use tokio::runtime::Runtime;
+use uuid::Uuid;
+
+fn sample_event() -> LedgerEvent {
+    let invocation = Invocation {
+        id: Uuid::new_v4(),
+        phrase: "test".into(),
+        invoker: "tester".into(),
+        invoked: "construct".into(),
+        tier: InvocationTier::True,
+        mode: InvocationMode::Read,
+        resonance_required: false,
+        timestamp: chrono::Utc::now(),
+    };
+    let cost = InvocationCost::default();
+    LedgerEvent { invocation, cost }
+}
+
+#[test]
+fn ledger_service_behaviors() {
+    let rt = Runtime::new().unwrap();
+
+    // scenario 1: buffer before DB ready
+    let (handle, service) = ledger_service::start(8, 5);
+    for _ in 0..10 {
+        handle.try_log(sample_event()).ok();
+    }
+    rt.block_on(async {
+        let _ = database::init_sqlite_connection("sqlite::memory:").await;
+        Migrator::up(database::get_db_connection(), None).await.unwrap();
+    });
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(50));
+    let conn = database::get_db_connection();
+    let count = rt.block_on(async { LedgerEntity::find().count(conn).await.unwrap() });
+    assert_eq!(count, 5);
+    service.shutdown(Duration::from_millis(50));
+
+    // scenario 2: backpressure on small channel
+    rt.block_on(async { LedgerEntity::delete_many().exec(conn).await.unwrap(); });
+    let (handle, service) = ledger_service::start(2, 0);
+    let mut accepted = 0;
+    for _ in 0..10 {
+        if handle.try_log(sample_event()).is_ok() {
+            accepted += 1;
+        }
+    }
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(50));
+    assert_eq!(rt.block_on(async { LedgerEntity::find().count(conn).await.unwrap() }), accepted as u64);
+    service.shutdown(Duration::from_millis(50));
+
+    // scenario 3: happy path after DB ready
+    rt.block_on(async { LedgerEntity::delete_many().exec(conn).await.unwrap(); });
+    let (handle, service) = ledger_service::start(8, 5);
+    let mut accepted = 0;
+    for _ in 0..20 {
+        if handle.try_log(sample_event()).is_ok() {
+            accepted += 1;
+        }
+    }
+    drop(handle);
+    std::thread::sleep(Duration::from_millis(50));
+    assert_eq!(rt.block_on(async { LedgerEntity::find().count(conn).await.unwrap() }), accepted as u64);
+    service.shutdown(Duration::from_millis(50));
+}

--- a/scroll_core/tests/chat_e2e.rs
+++ b/scroll_core/tests/chat_e2e.rs
@@ -7,8 +7,9 @@ use scroll_core::chat::chat_session::ChatSession;
 use scroll_core::core::construct_registry::ConstructRegistry;
 use scroll_core::core::context_frame_engine::{ContextFrameEngine, ContextMode};
 use scroll_core::invocation::aelren::AelrenHerald;
-use scroll_core::invocation::constructs::openai_construct::{Mythscribe, OpenAIClient};
+use scroll_core::invocation::constructs::openai_construct::Mythscribe;
 use scroll_core::invocation::invocation_manager::InvocationManager;
+use scroll_core::invocation::llm::factory;
 use scroll_core::trigger_loom::emotional_state::EmotionalState;
 
 use wiremock::matchers::{method, path};
@@ -38,12 +39,13 @@ async fn test_chat_dispatcher_records_access() {
     )));
 
     let mut registry = ConstructRegistry::new();
-    let client = OpenAIClient {
-        api_key: "test".into(),
-        model: "gpt-4o".into(),
-        endpoint: format!("{}/v1/chat/completions", server.uri()),
-        max_tokens: 50,
-    };
+    std::env::set_var("SC_LLM_PROVIDER", "openai");
+    std::env::set_var("OPENAI_API_KEY", "test");
+    std::env::set_var(
+        "SC_LLM_ENDPOINT",
+        format!("{}/v1/chat/completions", server.uri()),
+    );
+    let client = factory::from_env().unwrap();
     registry.insert("mythscribe", Mythscribe::new(client, "System".into()));
     let manager = Box::leak(Box::new(InvocationManager::new(registry)));
 


### PR DESCRIPTION
## Summary
- add async ledger service to buffer and flush invocation logs once the database is ready
- wire ledger handle through `InvocationManager` and CLI startup paths
- document and test channel buffering and drop behavior

## Testing
- `cargo test --test a_ledger_service_tests --test chat_e2e`


------
https://chatgpt.com/codex/tasks/task_e_68978c138a98833089fbc036f42ab396