### PR TITLE
Introduce async ledger service with optional gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ Run `cargo xtask gen-map` to regenerate `docs/module_map.md` after code changes.
 ## Alignment Docs
 
 Active plan, progress, and specs for aligning the runtime with the scrollbooks are tracked in `docs/alignment/`.
+
+## Ledger Service
+
+Invocation logging runs through a background service. It can be disabled by
+setting `SC_LEDGER_DISABLE=1`.

--- a/scroll_core/README.md
+++ b/scroll_core/README.md
@@ -9,4 +9,15 @@ Key entry points:
 - `invocation/`: constructs and invocation manager
 - `chat/`: interactive chat and routing
 
+## Migration Notes (Ledger Service)
+
+Invocation logging now uses a long-lived asynchronous service. It accepts
+events over a bounded channel and persists them once the database is ready.
+
+- Database URL is read from `DATABASE_URL` and defaults to
+  `sqlite://scroll_core.db?mode=rwc`.
+- To disable the service, set `SC_LEDGER_DISABLE=1`.
+- The service can be started with `ledger_service::start` and shut down with
+  `LedgerService::shutdown`.
+
 

--- a/scroll_core/src/invocation/invocation_manager.rs
+++ b/scroll_core/src/invocation/invocation_manager.rs
@@ -15,12 +15,15 @@ use crate::trigger_loom::ambient;
 use chrono::Utc;
 use uuid::Uuid;
 
+use crate::invocation::ledger_service::{LedgerEvent, LedgerHandle};
+
 use crate::Scroll;
 use tracing::info_span;
 
 pub struct InvocationManager {
     pub registry: ConstructRegistry,
     pub max_chain_depth: usize,
+    pub ledger: Option<LedgerHandle>,
 }
 
 impl InvocationManager {
@@ -28,7 +31,13 @@ impl InvocationManager {
         Self {
             registry,
             max_chain_depth: 3,
+            ledger: None,
         }
+    }
+
+    pub fn with_ledger(mut self, ledger: LedgerHandle) -> Self {
+        self.ledger = Some(ledger);
+        self
     }
 
     pub fn invoke_by_name(
@@ -93,20 +102,10 @@ impl InvocationManager {
 
         let result = self.registry.invoke(name, context);
 
-        // Opportunistic ledger write (ignore errors), fire-and-forget off-thread to avoid requiring a runtime
-        #[cfg(not(test))]
-        {
-            let inv = invocation.clone();
-            let cost_clone = cost.clone();
-            std::thread::spawn(move || {
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    rt.block_on(async {
-                        // Enrich decision string with routed construct
-                        let enriched = cost_clone.clone();
-                        if let CostDecision::Allow = enriched.decision {}
-                        let _ = crate::invocation::ledger::log_invocation_db(&inv, &enriched).await;
-                    });
-                }
+        if let Some(handle) = &self.ledger {
+            let _ = handle.try_log(LedgerEvent {
+                invocation: invocation.clone(),
+                cost: cost.clone(),
             });
         }
 
@@ -140,14 +139,9 @@ impl InvocationManager {
                 timestamp: Utc::now(),
             };
             let cost = InvocationCost::default();
-            let _ = std::thread::spawn(move || {
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    rt.block_on(async {
-                        let _ =
-                            crate::invocation::ledger::log_invocation_db(&invocation, &cost).await;
-                    });
-                }
-            });
+            if let Some(handle) = &self.ledger {
+                let _ = handle.try_log(LedgerEvent { invocation, cost });
+            }
         }
         herald.invoke_symbolically(scroll, &self.registry)
     }

--- a/scroll_core/src/invocation/ledger_service.rs
+++ b/scroll_core/src/invocation/ledger_service.rs
@@ -1,0 +1,140 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::core::cost_manager::InvocationCost;
+use crate::invocation::ledger::log_invocation_db;
+use crate::invocation::types::Invocation;
+use crate::sessions::database;
+
+/// Event containing an invocation and its cost.
+#[derive(Clone)]
+pub struct LedgerEvent {
+    pub invocation: Invocation,
+    pub cost: InvocationCost,
+}
+
+#[async_trait]
+pub trait LedgerWriter: Send + Sync + 'static {
+    async fn write(&self, event: &LedgerEvent) -> Result<(), sea_orm::DbErr>;
+}
+
+pub struct SeaOrmLedgerWriter;
+
+#[async_trait]
+impl LedgerWriter for SeaOrmLedgerWriter {
+    async fn write(&self, event: &LedgerEvent) -> Result<(), sea_orm::DbErr> {
+        log_invocation_db(&event.invocation, &event.cost).await
+    }
+}
+
+#[derive(Clone)]
+pub struct LedgerHandle {
+    tx: mpsc::Sender<LedgerEvent>,
+}
+
+impl LedgerHandle {
+    pub fn try_log(
+        &self,
+        event: LedgerEvent,
+    ) -> Result<(), mpsc::error::TrySendError<LedgerEvent>> {
+        self.tx.try_send(event)
+    }
+}
+
+pub struct LedgerService {
+    handle: Option<tokio::task::JoinHandle<()>>,
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl LedgerService {
+    pub fn shutdown(mut self, timeout: Duration) {
+        if let (Some(rt), Some(handle)) = (self.runtime.take(), self.handle.take()) {
+            let _ = rt.block_on(async { let _ = tokio::time::timeout(timeout, handle).await; });
+        }
+    }
+}
+
+/// Starts the ledger service with given channel and staging capacities.
+pub fn start(
+    chan_capacity: usize,
+    staging_capacity: usize,
+) -> (LedgerHandle, LedgerService) {
+    start_with_writer(chan_capacity, staging_capacity, Arc::new(SeaOrmLedgerWriter))
+}
+
+fn start_with_writer(
+    chan_capacity: usize,
+    staging_capacity: usize,
+    writer: Arc<dyn LedgerWriter>,
+) -> (LedgerHandle, LedgerService) {
+    let (tx, mut rx) = mpsc::channel::<LedgerEvent>(chan_capacity);
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+
+    let handle = rt.spawn(async move {
+        let mut staging: VecDeque<LedgerEvent> = VecDeque::with_capacity(staging_capacity);
+        loop {
+            if !database::is_initialized() {
+                if staging_capacity > 0 {
+                    match rx.recv().await {
+                        Some(ev) => {
+                            if staging.len() == staging_capacity {
+                                staging.pop_front();
+                            }
+                            staging.push_back(ev);
+                        }
+                        None => {
+                            if database::is_initialized() {
+                                while let Some(ev) = staging.pop_front() {
+                                    if let Err(e) = writer.write(&ev).await {
+                                        tracing::warn!("ledger write failed: {}", e);
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                    }
+                } else {
+                    if rx.is_closed() {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                continue;
+            }
+
+            while let Some(ev) = staging.pop_front() {
+                if let Err(e) = writer.write(&ev).await {
+                    tracing::warn!("ledger write failed: {}", e);
+                }
+            }
+
+            match rx.recv().await {
+                Some(ev) => {
+                    if let Err(e) = writer.write(&ev).await {
+                        tracing::warn!("ledger write failed: {}", e);
+                    }
+                }
+                None => {
+                    while let Some(ev) = staging.pop_front() {
+                        if let Err(e) = writer.write(&ev).await {
+                            tracing::warn!("ledger write failed: {}", e);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    (
+        LedgerHandle { tx },
+        LedgerService {
+            handle: Some(handle),
+            runtime: Some(rt),
+        },
+    )
+}

--- a/scroll_core/src/invocation/mod.rs
+++ b/scroll_core/src/invocation/mod.rs
@@ -10,6 +10,7 @@ pub mod constructs;
 pub mod llm;
 pub mod invocation_manager;
 pub mod ledger;
+pub mod ledger_service;
 pub mod named_construct;
 pub mod types;
 

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Result;
 use std::path::Path;
+use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 use dotenvy::dotenv;
@@ -25,6 +26,7 @@ use scroll_core::{
         aelren::AelrenHerald,
         constructs::openai_construct::Mythscribe,
         invocation_manager::InvocationManager,
+        ledger_service,
         llm::factory,
     },
     parser::parse_scroll,
@@ -120,6 +122,15 @@ fn main() -> Result<()> {
         let _ = rt.block_on(scroll_core::sessions::database::init_sqlite_connection(
             &db_url,
         ));
+        let _ = rt.block_on(migration::Migrator::up(
+            scroll_core::sessions::database::get_db_connection(),
+            None,
+        ));
+        let ledger = if std::env::var("SC_LEDGER_DISABLE").is_err() {
+            Some(ledger_service::start(64, 256))
+        } else {
+            None
+        };
         let mut archive = InMemoryArchive::new(scrolls.clone());
         // Build semantic index for context modes that rely on it
         {
@@ -140,8 +151,10 @@ fn main() -> Result<()> {
             registry.insert("mythscribe", mythscribe);
         }
         // Optional: attach a pulse-sensitive construct to bus later (Phase 6)
-
-        let manager = InvocationManager::new(registry);
+        let mut manager = InvocationManager::new(registry);
+        if let Some((ref handle, _)) = ledger {
+            manager = manager.with_ledger(handle.clone());
+        }
         let aelren = AelrenHerald::new(engine, vec![construct.clone()]);
         let stream_enabled = *stream && !*no_stream;
         let theme_struct = theme.styles();
@@ -154,6 +167,10 @@ fn main() -> Result<()> {
             theme_struct,
             !*no_banner,
         )?;
+        if let Some((handle, service)) = ledger {
+            drop(handle);
+            service.shutdown(Duration::from_millis(250));
+        }
         teardown_scroll_core();
         return Ok(());
     }
@@ -270,31 +287,43 @@ fn main() -> Result<()> {
             registry.insert("mythscribe", mythscribe);
 
             // Ensure DB connection and migrations for CLI ledger/session logging
-            {
-                let db_url = std::env::var("DATABASE_URL")
-                    .unwrap_or_else(|_| "sqlite://scroll_core.db?mode=rwc".into());
-                if !scroll_core::sessions::database::is_initialized() {
-                    if let Ok(rt) = tokio::runtime::Runtime::new() {
-                        rt.block_on(async {
-                            if scroll_core::sessions::database::init_sqlite_connection(&db_url)
-                                .await
-                                .is_ok()
-                            {
-                                let _ = migration::Migrator::up(
-                                    scroll_core::sessions::database::get_db_connection(),
-                                    None,
-                                )
-                                .await;
-                            }
-                        });
-                    }
+            let db_url = std::env::var("DATABASE_URL")
+                .unwrap_or_else(|_| "sqlite://scroll_core.db?mode=rwc".into());
+            if !scroll_core::sessions::database::is_initialized() {
+                if let Ok(rt) = tokio::runtime::Runtime::new() {
+                    rt.block_on(async {
+                        if scroll_core::sessions::database::init_sqlite_connection(&db_url)
+                            .await
+                            .is_ok()
+                        {
+                            let _ = migration::Migrator::up(
+                                scroll_core::sessions::database::get_db_connection(),
+                                None,
+                            )
+                            .await;
+                        }
+                    });
                 }
             }
 
-            let manager = InvocationManager::new(registry);
+            let ledger = if std::env::var("SC_LEDGER_DISABLE").is_err() {
+                Some(ledger_service::start(64, 256))
+            } else {
+                None
+            };
+
+            let mut manager = InvocationManager::new(registry);
+            if let Some((ref handle, _)) = ledger {
+                manager = manager.with_ledger(handle.clone());
+            }
             let aelren = AelrenHerald::new(engine, vec!["mythscribe".into()]);
 
             scroll_core::system::cli_orchestrator::run_cli(&manager, &aelren, &scrolls);
+
+            if let Some((handle, service)) = ledger {
+                drop(handle);
+                service.shutdown(Duration::from_millis(250));
+            }
         }
         Err(e) => eprintln!("❌ Initialization failed: {e}"),
     }

--- a/scroll_core/src/sessions/database.rs
+++ b/scroll_core/src/sessions/database.rs
@@ -8,6 +8,7 @@ use sea_orm::{Database, DbConn, DbErr};
 
 static DB_CONNECTION: OnceCell<DbConn> = OnceCell::new();
 
+
 /// Initializes and stores a global database connection pool.
 ///
 /// Call this once on application startup. Subsequent calls will fail
@@ -43,3 +44,4 @@ pub fn get_db_connection() -> &'static DbConn {
 pub fn is_initialized() -> bool {
     DB_CONNECTION.get().is_some()
 }
+

--- a/scroll_core/tests/chat_e2e.rs
+++ b/scroll_core/tests/chat_e2e.rs
@@ -7,7 +7,9 @@ use scroll_core::chat::chat_session::ChatSession;
 use scroll_core::core::construct_registry::ConstructRegistry;
 use scroll_core::core::context_frame_engine::{ContextFrameEngine, ContextMode};
 use scroll_core::invocation::aelren::AelrenHerald;
-use scroll_core::invocation::constructs::openai_construct::{Mythscribe, OpenAIClient};
+use scroll_core::invocation::constructs::openai_construct::Mythscribe;
+use scroll_core::invocation::llm::openai::OpenAIClient;
+use std::sync::Arc;
 use scroll_core::invocation::invocation_manager::InvocationManager;
 use scroll_core::trigger_loom::emotional_state::EmotionalState;
 
@@ -38,12 +40,13 @@ async fn test_chat_dispatcher_records_access() {
     )));
 
     let mut registry = ConstructRegistry::new();
-    let client = OpenAIClient {
-        api_key: "test".into(),
-        model: "gpt-4o".into(),
-        endpoint: format!("{}/v1/chat/completions", server.uri()),
-        max_tokens: 50,
-    };
+    std::env::set_var("OPENAI_API_KEY", "test");
+    std::env::set_var("SC_LLM_MODEL", "gpt-4o");
+    std::env::set_var(
+        "SC_LLM_ENDPOINT",
+        format!("{}/v1/chat/completions", server.uri()),
+    );
+    let client = Arc::new(OpenAIClient::new_from_env().unwrap());
     registry.insert("mythscribe", Mythscribe::new(client, "System".into()));
     let manager = Box::leak(Box::new(InvocationManager::new(registry)));
 

--- a/scroll_core/tests/ledger_service_tests.rs
+++ b/scroll_core/tests/ledger_service_tests.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use migration::{Migrator, MigratorTrait};
+use sea_orm::{EntityTrait, PaginatorTrait};
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+
+use scroll_core::core::cost_manager::InvocationCost;
+use scroll_core::invocation::ledger::Entity as LedgerEntity;
+use scroll_core::invocation::ledger_service::{start, LedgerEvent};
+use scroll_core::invocation::types::{Invocation, InvocationMode, InvocationTier};
+use scroll_core::sessions::database;
+
+fn make_event(i: i32) -> LedgerEvent {
+    LedgerEvent {
+        invocation: Invocation {
+            id: Uuid::new_v4(),
+            phrase: format!("p{}", i),
+            invoker: "test".into(),
+            invoked: "test".into(),
+            tier: InvocationTier::True,
+            mode: InvocationMode::Read,
+            resonance_required: false,
+            timestamp: Utc::now(),
+        },
+        cost: InvocationCost::default(),
+    }
+}
+
+#[test]
+fn buffers_until_db_ready_then_flushes() {
+    let (handle, service) = start(8, 5);
+    for i in 0..10 {
+        let _ = handle.try_log(make_event(i));
+    }
+
+    let tmp = NamedTempFile::new().unwrap();
+    let db_url = format!("sqlite://{}?mode=rwc", tmp.path().to_str().unwrap());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        database::init_sqlite_connection(&db_url).await.unwrap();
+        Migrator::up(database::get_db_connection(), None).await.unwrap();
+    });
+
+    drop(handle);
+    service.shutdown(Duration::from_millis(200));
+
+    let count = rt
+        .block_on(async {
+            LedgerEntity::find()
+                .count(database::get_db_connection())
+                .await
+                .unwrap()
+        });
+    assert_eq!(count, 5);
+}


### PR DESCRIPTION
## Summary
- add asynchronous ledger service with bounded channel and staging buffer
- hook InvocationManager and CLI to use the service, gated by `SC_LEDGER_DISABLE`
- document ledger service and add basic buffering test

## Testing
- `cargo test --test ledger_service_tests --test chat_e2e -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68978c138a98833089fbc036f42ab396