### PR TITLE
Context engine upgrades

### DIFF
--- a/docs/alignment/CHECKLIST.md
+++ b/docs/alignment/CHECKLIST.md
@@ -31,7 +31,7 @@
 - [ ] Contradiction detection stub
 
 ## Phase 5
-- [ ] Context thresholds configurable; decisions logged
+- [x] Context thresholds configurable; decisions logged
 
 ## Phase 6
 - [ ] Orchestrated construct demo; dispatcher receive loop

--- a/docs/architecture/runtime/context-engine.md
+++ b/docs/architecture/runtime/context-engine.md
@@ -40,4 +40,38 @@ To speed up warm starts, the semantic index persists to an OS-specific cache dir
 
 Environment toggles are documented in `docs/reference/config.md`.
 
+## Thresholds and Reasons
+
+Context selection limits can be tuned globally or per construct in `models.yaml`:
+
+```yaml
+context:
+  decisions_verbose: false
+  defaults:
+    max_context_tokens: 3000
+    min_relevance_score: 0.35
+    recency_half_life_hours: 48
+    max_items: 12
+  constructs:
+    Mythscribe:
+      max_context_tokens: 4000
+```
+
+Environment variables override YAML values (`SC_CONTEXT_MAX_TOKENS`,
+`SC_CONTEXT_Mythscribe_MAX_ITEMS`, etc.). `SC_CONTEXT_DECISIONS_VERBOSE=true`
+enables detailed candidate logging to the context ledger.
+
+Each candidate evaluated by the engine is tagged with a reason code:
+
+| Code            | Meaning                                      |
+|-----------------|----------------------------------------------|
+| `Included`      | Candidate was added to the frame             |
+| `SelfExclusion` | Triggering scroll filtered from candidates   |
+| `LowRelevance`  | Below `min_relevance_score`                  |
+| `MaxItems`      | Exceeds `max_items` limit                    |
+| `TokenBudget`   | Would exceed `max_context_tokens`            |
+| `IncludedFallback` | Explicitly seeded fallback candidate     |
+
+Reason strings are stable and stored in the context ledger for later audit.
+
 

--- a/docs/dev/auditing-context-decisions.md
+++ b/docs/dev/auditing-context-decisions.md
@@ -1,0 +1,24 @@
+---
+title: Auditing Context Decisions
+status: draft
+audience: dev
+---
+
+# Auditing Context Decisions
+
+The context ledger records how each frame was assembled. Use the CLI to
+inspect recent frames or export them for analysis.
+
+## Examples
+
+```bash
+cargo run -- context --limit 10
+cargo run -- context --limit 5 --details
+cargo run -- context --limit 5 --details --export yaml
+```
+
+`--details` includes candidate rows. `--export` emits JSON or YAML instead
+of the human-readable table.
+
+Set `SC_CONTEXT_DECISIONS_VERBOSE=true` or `context.decisions_verbose: true`
+in `models.yaml` to persist candidate rows automatically.

--- a/scroll_core/src/core/context_frame_engine.rs
+++ b/scroll_core/src/core/context_frame_engine.rs
@@ -15,6 +15,7 @@ use crate::scroll::Scroll;
 use uuid::Uuid;
 
 use super::context_decisions::{ContextBuildReport, ContextDecision, ContextFrameSummary};
+use crate::invocation::context_reasons::ReasonCode;
 
 pub enum ContextMode {
     Narrow,
@@ -114,9 +115,6 @@ impl<'a> ContextFrameEngine<'a> {
             .query_semantic(&query, related.len().max(self.max_scrolls * 2))
             .into_iter()
             .filter_map(|(s, score)| {
-                if s.id == triggering_scroll.id {
-                    return None;
-                }
                 let age_hours = (now
                     .signed_duration_since(s.origin.last_modified)
                     .num_seconds()
@@ -128,9 +126,6 @@ impl<'a> ContextFrameEngine<'a> {
         // If semantic results empty (e.g., Narrow mode), synthesize candidates from related list with neutral score
         if candidates.is_empty() {
             for s in related {
-                if s.id == triggering_scroll.id {
-                    continue;
-                }
                 let age_hours = (now
                     .signed_duration_since(s.origin.last_modified)
                     .num_seconds()
@@ -151,21 +146,25 @@ impl<'a> ContextFrameEngine<'a> {
         let mut decisions: Vec<ContextDecision> = Vec::new();
         let mut included = 0usize;
         let mut excluded = 0usize;
-        for (idx, (s, score, age_h)) in candidates.into_iter().enumerate() {
-            let mut reason = String::new();
+        for (s, score, age_h) in candidates.into_iter() {
+            let mut reason = ReasonCode::Included;
             let mut include = true;
-            if score < self.thresholds.min_relevance_score {
+            if s.id == triggering_scroll.id {
                 include = false;
-                reason = "below_score_threshold".into();
+                reason = ReasonCode::SelfExclusion;
+            }
+            if include && score < self.thresholds.min_relevance_score {
+                include = false;
+                reason = ReasonCode::LowRelevance;
             }
             if include && scrolls.len() >= self.max_scrolls {
                 include = false;
-                reason = "max_items_limit".into();
+                reason = ReasonCode::MaxItems;
             }
             let item_tokens = token_estimate(&s);
             if include && running_tokens + item_tokens > self.thresholds.max_context_tokens {
                 include = false;
-                reason = "budget_exceeded".into();
+                reason = ReasonCode::TokenBudget;
             }
             if include {
                 running_tokens += item_tokens;
@@ -176,11 +175,7 @@ impl<'a> ContextFrameEngine<'a> {
                     frame_id,
                     candidate_path: s.yaml_metadata.file_path.clone(),
                     included: true,
-                    reason: if reason.is_empty() {
-                        "included".into()
-                    } else {
-                        reason
-                    },
+                    reason: reason.as_str().into(),
                     score: score as f32,
                     recency_hours: age_h,
                     running_tokens,
@@ -193,15 +188,7 @@ impl<'a> ContextFrameEngine<'a> {
                     frame_id,
                     candidate_path: s.yaml_metadata.file_path.clone(),
                     included: false,
-                    reason: if reason.is_empty() {
-                        if idx >= self.max_scrolls {
-                            "max_items_limit".into()
-                        } else {
-                            "excluded".into()
-                        }
-                    } else {
-                        reason
-                    },
+                    reason: reason.as_str().into(),
                     score: score as f32,
                     recency_hours: age_h,
                     running_tokens,
@@ -274,6 +261,7 @@ fn decay_score(score: f32, age_hours: f32, half_life_hours: f32) -> f32 {
 mod tests {
     use super::*;
     use crate::archive::archive_memory::InMemoryArchive;
+    use crate::invocation::context_reasons::ReasonCode;
     use crate::schema::{ScrollType, YamlMetadata};
 
     fn mk_scroll(title: &str, body_len: usize, age_hours: i64) -> Scroll {
@@ -330,5 +318,74 @@ mod tests {
         assert_eq!(ctx.scrolls.len(), 2);
         assert!(report.summary.included_count >= 1);
         assert!(report.summary.excluded_count >= 1);
+    }
+
+    #[test]
+    fn assigns_reason_codes() {
+        fn mk_body_scroll(title: &str, body: &str, age_hours: i64) -> Scroll {
+            let now = chrono::Utc::now() - chrono::Duration::hours(age_hours);
+            Scroll {
+                id: uuid::Uuid::new_v4(),
+                title: title.into(),
+                scroll_type: ScrollType::Canon,
+                yaml_metadata: YamlMetadata {
+                    title: title.into(),
+                    scroll_type: ScrollType::Canon,
+                    emotion_signature: crate::schema::EmotionSignature::neutral(),
+                    tags: vec!["t".into()],
+                    archetype: None,
+                    quorum_required: false,
+                    last_modified: Some(now),
+                    file_path: Some(format!("/tmp/{}.md", title)),
+                },
+                tags: vec!["t".into()],
+                archetype: None,
+                quorum_required: false,
+                markdown_body: body.into(),
+                invocation_phrase: String::new(),
+                sigil: String::new(),
+                status: crate::schema::ScrollStatus::Draft,
+                emotion_signature: crate::schema::EmotionSignature::neutral(),
+                linked_scrolls: vec![],
+                origin: crate::scroll::ScrollOrigin {
+                    created: now,
+                    authored_by: None,
+                    last_modified: now,
+                },
+            }
+        }
+
+        let s0 = mk_body_scroll("root", "alpha beta", 0);
+        let s1 = mk_body_scroll("a", "alpha beta", 2);
+        let s2 = mk_body_scroll("b", "alpha", 3);
+        let s3 = mk_body_scroll("c", "alpha", 4);
+        let s4 = mk_body_scroll("huge", &"alpha beta ".repeat(2000), 1);
+        let s5 = mk_body_scroll("irrelevant", "gamma", 5);
+        let mut archive = InMemoryArchive::new(vec![
+            s0.clone(),
+            s1.clone(),
+            s2.clone(),
+            s3.clone(),
+            s4.clone(),
+            s5.clone(),
+        ]);
+        let embedder = crate::archive::semantic_index::TokenEmbedder;
+        let _ = archive.build_semantic_index(&embedder);
+
+        let thresholds = ContextThresholds {
+            max_context_tokens: 100,
+            min_relevance_score: 0.5,
+            recency_half_life_hours: 48.0,
+            max_items: 3,
+        };
+        let engine = ContextFrameEngine::new(&archive, ContextMode::Broad)
+            .with_thresholds(thresholds)
+            .with_construct_label("Test");
+        let (_ctx, report) = engine.build_context(&s0);
+        let reasons: Vec<String> = report.decisions.iter().map(|d| d.reason.clone()).collect();
+        assert!(reasons.contains(&ReasonCode::SelfExclusion.as_str().into()));
+        assert!(reasons.contains(&ReasonCode::Included.as_str().into()));
+        assert!(reasons.contains(&ReasonCode::TokenBudget.as_str().into()));
+        assert!(reasons.contains(&ReasonCode::LowRelevance.as_str().into()));
     }
 }

--- a/scroll_core/src/invocation/aelren.rs
+++ b/scroll_core/src/invocation/aelren.rs
@@ -24,6 +24,7 @@ pub struct AelrenHerald<'a> {
     pub frame_engine: ContextFrameEngine<'a>,
     pub registry_snapshot: Vec<String>,
     pub explain_context: bool,
+    pub decisions_verbose: bool,
 }
 
 impl<'a> AelrenHerald<'a> {
@@ -32,6 +33,7 @@ impl<'a> AelrenHerald<'a> {
             frame_engine,
             registry_snapshot,
             explain_context: false,
+            decisions_verbose: false,
         }
     }
 
@@ -46,15 +48,16 @@ impl<'a> AelrenHerald<'a> {
         };
 
         // Persist decisions to ledger (best effort)
-        let verbose = self.explain_context;
+        let explain = self.explain_context;
+        let verbose = self.decisions_verbose;
         let report_clone = report.clone();
         let _ = tokio::runtime::Runtime::new().map(|rt| {
             rt.block_on(async move {
-                let _ = log_context_report(&report_clone).await;
+                let _ = log_context_report(&report_clone, verbose).await;
             })
         });
 
-        if verbose {
+        if explain {
             // Print simple table of decisions
             println!("Context decisions ({}):", report.summary.construct);
             println!("- frame: {}", report.summary.frame_id);

--- a/scroll_core/src/invocation/context_ledger.rs
+++ b/scroll_core/src/invocation/context_ledger.rs
@@ -1,5 +1,6 @@
 use sea_orm::entity::prelude::*;
 use sea_orm::Set;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::core::context_decisions::ContextBuildReport;
@@ -7,7 +8,7 @@ use crate::sessions::database::get_db_connection;
 
 pub mod frame {
     use super::*;
-    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
     #[sea_orm(table_name = "context_frame_ledger")]
     pub struct Model {
         #[sea_orm(primary_key)]
@@ -30,7 +31,7 @@ pub mod frame {
 
 pub mod candidate {
     use super::*;
-    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
     #[sea_orm(table_name = "context_candidate_ledger")]
     pub struct Model {
         #[sea_orm(primary_key)]
@@ -51,7 +52,10 @@ pub mod candidate {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
-pub async fn log_context_report(report: &ContextBuildReport) -> Result<(), sea_orm::DbErr> {
+pub async fn log_context_report(
+    report: &ContextBuildReport,
+    verbose: bool,
+) -> Result<(), sea_orm::DbErr> {
     // Do nothing if DB is not initialized
     if !crate::sessions::database::is_initialized() {
         return Ok(());
@@ -74,10 +78,6 @@ pub async fn log_context_report(report: &ContextBuildReport) -> Result<(), sea_o
     let _ = frame.insert(conn).await?;
 
     // Optional detail rows
-    let verbose = std::env::var("SC_CONTEXT_DECISIONS_VERBOSE")
-        .ok()
-        .as_deref()
-        == Some("1");
     if verbose {
         for d in &report.decisions {
             let rec = candidate::ActiveModel {

--- a/scroll_core/src/invocation/context_reasons.rs
+++ b/scroll_core/src/invocation/context_reasons.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub enum ReasonCode {
+    Included,
+    IncludedFallback,
+    SelfExclusion,
+    LowRelevance,
+    MaxItems,
+    TokenBudget,
+    Excluded,
+}
+
+impl ReasonCode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReasonCode::Included => "Included",
+            ReasonCode::IncludedFallback => "IncludedFallback",
+            ReasonCode::SelfExclusion => "SelfExclusion",
+            ReasonCode::LowRelevance => "LowRelevance",
+            ReasonCode::MaxItems => "MaxItems",
+            ReasonCode::TokenBudget => "TokenBudget",
+            ReasonCode::Excluded => "Excluded",
+        }
+    }
+}
+
+impl Display for ReasonCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}

--- a/scroll_core/src/invocation/mod.rs
+++ b/scroll_core/src/invocation/mod.rs
@@ -8,6 +8,7 @@
 pub mod aelren;
 pub mod constructs;
 pub mod context_ledger;
+pub mod context_reasons;
 pub mod invocation_manager;
 pub mod ledger;
 pub mod ledger_service;

--- a/scroll_core/src/main.rs
+++ b/scroll_core/src/main.rs
@@ -99,6 +99,11 @@ enum Commands {
         /// Also print candidate detail rows
         #[arg(long = "details", action = clap::ArgAction::SetTrue, default_value_t = false)]
         details: bool,
+        #[arg(
+            long = "export",
+            value_parser = clap::builder::PossibleValuesParser::new(["json", "yaml"])
+        )]
+        export: Option<String>,
     },
     /// Archive index operations
     Index {
@@ -269,6 +274,7 @@ fn main() -> Result<()> {
         let manager = InvocationManager::new(registry).with_ledger(ledger_handle.clone());
         let mut aelren = AelrenHerald::new(engine, vec![construct.clone()]);
         aelren.explain_context = *explain_context;
+        aelren.decisions_verbose = model_registry.context_decisions_verbose();
         let stream_enabled = *stream && !*no_stream;
         let theme_struct = theme.styles();
         run_chat(
@@ -611,7 +617,12 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    if let Some(Commands::Context { limit, details }) = &cli.command {
+    if let Some(Commands::Context {
+        limit,
+        details,
+        export,
+    }) = &cli.command
+    {
         // Ensure DB is ready
         let db_url =
             std::env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite://scroll_core.db".into());
@@ -623,6 +634,7 @@ fn main() -> Result<()> {
         })?;
         use scroll_core::invocation::context_ledger::{candidate, frame};
         use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+        use serde::Serialize;
         let frames: Vec<frame::Model> = tokio::runtime::Runtime::new()?.block_on(async move {
             frame::Entity::find()
                 .order_by_desc(frame::Column::Timestamp)
@@ -631,26 +643,18 @@ fn main() -> Result<()> {
                 .await
                 .unwrap_or_default()
         });
-        println!("Latest {} context frames:", frames.len());
-        for f in &frames {
-            println!(
-                "- frame={} construct={} max_tokens={} max_items={} min_rel={:.2} half_life_h={:.1} candidates={} included={} excluded={} build_ms={} at {}",
-                f.frame_id,
-                f.construct,
-                f.max_tokens,
-                f.max_items,
-                f.min_relevance,
-                f.half_life_hours,
-                f.total_candidates,
-                f.included_count,
-                f.excluded_count,
-                f.build_ms,
-                f.timestamp
-            );
-            if *details {
-                let conn2 = scroll_core::sessions::database::get_db_connection().clone();
-                let rows: Vec<candidate::Model> =
-                    tokio::runtime::Runtime::new()?.block_on(async move {
+        if let Some(fmt) = export {
+            #[derive(Serialize)]
+            struct FrameExport {
+                frame: frame::Model,
+                candidates: Vec<candidate::Model>,
+            }
+            let mut out = Vec::new();
+            for f in frames {
+                let mut candidates_vec = Vec::new();
+                if *details {
+                    let conn2 = scroll_core::sessions::database::get_db_connection().clone();
+                    candidates_vec = tokio::runtime::Runtime::new()?.block_on(async move {
                         candidate::Entity::find()
                             .filter(candidate::Column::FrameId.eq(f.frame_id))
                             .order_by_asc(candidate::Column::Timestamp)
@@ -658,18 +662,59 @@ fn main() -> Result<()> {
                             .await
                             .unwrap_or_default()
                     });
-                for r in rows {
-                    let mark = if r.included { "✔" } else { "✖" };
-                    println!(
-                        "  {} {} score={:.2} age_h={:.1} tokens={}/{} reason={}",
-                        mark,
-                        r.candidate_path.unwrap_or_else(|| "<unknown>".into()),
-                        r.score,
-                        r.recency_hours,
-                        r.running_tokens,
-                        r.max_tokens,
-                        r.reason
-                    );
+                }
+                out.push(FrameExport {
+                    frame: f,
+                    candidates: candidates_vec,
+                });
+            }
+            let serialized = if fmt == "json" {
+                serde_json::to_string_pretty(&out)?
+            } else {
+                serde_yaml::to_string(&out)?
+            };
+            println!("{}", serialized);
+        } else {
+            println!("Latest {} context frames:", frames.len());
+            for f in &frames {
+                println!(
+                    "- frame={} construct={} max_tokens={} max_items={} min_rel={:.2} half_life_h={:.1} candidates={} included={} excluded={} build_ms={} at {}",
+                    f.frame_id,
+                    f.construct,
+                    f.max_tokens,
+                    f.max_items,
+                    f.min_relevance,
+                    f.half_life_hours,
+                    f.total_candidates,
+                    f.included_count,
+                    f.excluded_count,
+                    f.build_ms,
+                    f.timestamp
+                );
+                if *details {
+                    let conn2 = scroll_core::sessions::database::get_db_connection().clone();
+                    let rows: Vec<candidate::Model> =
+                        tokio::runtime::Runtime::new()?.block_on(async move {
+                            candidate::Entity::find()
+                                .filter(candidate::Column::FrameId.eq(f.frame_id))
+                                .order_by_asc(candidate::Column::Timestamp)
+                                .all(&conn2)
+                                .await
+                                .unwrap_or_default()
+                        });
+                    for r in rows {
+                        let mark = if r.included { "✔" } else { "✖" };
+                        println!(
+                            "  {} {} score={:.2} age_h={:.1} tokens={}/{} reason={}",
+                            mark,
+                            r.candidate_path.unwrap_or_else(|| "<unknown>".into()),
+                            r.score,
+                            r.recency_hours,
+                            r.running_tokens,
+                            r.max_tokens,
+                            r.reason
+                        );
+                    }
                 }
             }
         }

--- a/scroll_core/src/models/model_registry.rs
+++ b/scroll_core/src/models/model_registry.rs
@@ -56,6 +56,8 @@ pub struct ContextConfig {
     pub defaults: ContextThresholds,
     #[serde(default)]
     pub constructs: HashMap<String, ContextThresholds>,
+    #[serde(default)]
+    pub decisions_verbose: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -86,6 +88,7 @@ pub struct ModelRegistry {
     source_file: Option<PathBuf>,
     context_defaults: ContextThresholds,
     context_constructs: HashMap<String, ContextThresholds>,
+    context_decisions_verbose: bool,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -119,6 +122,7 @@ impl ModelRegistry {
         let mut source_file: Option<PathBuf> = None;
         let mut context_defaults: ContextThresholds = ContextThresholds::default();
         let mut context_constructs: HashMap<String, ContextThresholds> = HashMap::new();
+        let mut decisions_verbose: bool = false;
 
         // 2) load YAML if present
         let yaml_path = resolve_config_path(path);
@@ -135,6 +139,7 @@ impl ModelRegistry {
                         if let Some(ctx) = cfg.context {
                             context_defaults = ctx.defaults;
                             context_constructs = ctx.constructs;
+                            decisions_verbose = ctx.decisions_verbose;
                         }
                     }
                     Err(e) => return Err(RegistryError::Load(e.to_string())),
@@ -147,7 +152,11 @@ impl ModelRegistry {
         apply_global_env_overrides(&mut default_spec)?;
         apply_construct_env_overrides(&mut constructs)?;
         apply_cost_env_overrides(&mut cost_profiles)?;
-        apply_context_env_overrides(&mut context_defaults, &mut context_constructs)?;
+        apply_context_env_overrides(
+            &mut context_defaults,
+            &mut context_constructs,
+            &mut decisions_verbose,
+        )?;
 
         Ok(Self {
             default_spec,
@@ -156,6 +165,7 @@ impl ModelRegistry {
             source_file,
             context_defaults,
             context_constructs,
+            context_decisions_verbose: decisions_verbose,
         })
     }
 
@@ -187,15 +197,32 @@ impl ModelRegistry {
             context: ContextConfig {
                 defaults: self.context_defaults.clone(),
                 constructs: self.context_constructs.clone(),
+                decisions_verbose: self.context_decisions_verbose,
             },
         }
     }
 
     pub fn context_for(&self, construct: &str) -> ContextThresholds {
-        self.context_constructs
-            .get(construct)
-            .cloned()
-            .unwrap_or_else(|| self.context_defaults.clone())
+        if let Some(th) = self.context_constructs.get(construct) {
+            th.clone()
+        } else {
+            use once_cell::sync::Lazy;
+            use std::collections::HashSet;
+            use std::sync::Mutex;
+            static WARNED: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+            let mut w = WARNED.lock().unwrap();
+            if w.insert(construct.to_string()) {
+                tracing::warn!(
+                    "context thresholds for unknown construct '{}' falling back to defaults",
+                    construct
+                );
+            }
+            self.context_defaults.clone()
+        }
+    }
+
+    pub fn context_decisions_verbose(&self) -> bool {
+        self.context_decisions_verbose
     }
 }
 
@@ -339,6 +366,7 @@ fn apply_cost_env_overrides(
 fn apply_context_env_overrides(
     defaults: &mut ContextThresholds,
     constructs: &mut HashMap<String, ContextThresholds>,
+    decisions_verbose: &mut bool,
 ) -> Result<(), RegistryError> {
     if let Ok(v) = std::env::var("SC_CONTEXT_MAX_TOKENS") {
         if let Ok(n) = v.parse::<usize>() {
@@ -359,6 +387,10 @@ fn apply_context_env_overrides(
         if let Ok(n) = v.parse::<usize>() {
             defaults.max_items = n;
         }
+    }
+    if let Ok(v) = std::env::var("SC_CONTEXT_DECISIONS_VERBOSE") {
+        let v_lower = v.to_lowercase();
+        *decisions_verbose = v_lower == "1" || v_lower == "true";
     }
     // Per-construct
     for (k, v) in std::env::vars() {
@@ -507,5 +539,32 @@ context:
 
         std::env::remove_var("SC_CONTEXT_MAX_TOKENS");
         std::env::remove_var("SC_CONTEXT_Mythscribe_MAX_ITEMS");
+    }
+
+    #[test]
+    fn decisions_verbose_env_over_yaml_over_default() {
+        let dir = tempdir().unwrap();
+        let yaml = dir.path().join("models.yaml");
+        fs::write(
+            &yaml,
+            r#"version: 1
+context:
+  decisions_verbose: true
+  defaults:
+    max_context_tokens: 3000
+    min_relevance_score: 0.4
+    recency_half_life_hours: 24
+    max_items: 10
+"#,
+        )
+        .unwrap();
+
+        std::env::set_var("SC_CONTEXT_DECISIONS_VERBOSE", "false");
+        let reg = ModelRegistry::from_env_and_file(Some(&yaml)).unwrap();
+        assert!(!reg.context_decisions_verbose());
+        std::env::remove_var("SC_CONTEXT_DECISIONS_VERBOSE");
+
+        let reg2 = ModelRegistry::from_env_and_file(Some(&yaml)).unwrap();
+        assert!(reg2.context_decisions_verbose());
     }
 }

--- a/tests/context_cli_export.rs
+++ b/tests/context_cli_export.rs
@@ -1,0 +1,13 @@
+#[test]
+fn context_cli_exports_json() {
+    use assert_cmd::Command;
+    use serde_json::Value;
+    let output = Command::cargo_bin("scroll_core")
+        .unwrap()
+        .args(["context", "--limit", "1", "--details", "--export", "json"])
+        .output()
+        .expect("run");
+    assert!(output.status.success());
+    let s = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str::<Value>(&s).expect("valid json");
+}


### PR DESCRIPTION
## Summary
- add per-construct context decision verbosity to model registry
- standardize context reason codes and record them in the ledger
- extend `context` CLI with export options and auditing docs

## Testing
- `cargo test`
- `cargo run --quiet -- context --limit 1 --details --export json`

------
https://chatgpt.com/codex/tasks/task_e_68990021f4248330840b4c52908bfa30