### PR TITLE
feat: add ambient orchestrator demo

### DIFF
--- a/docs/user-guides/trigger-loom-demo.md
+++ b/docs/user-guides/trigger-loom-demo.md
@@ -11,18 +11,24 @@ This guide wires together the **PulseEcho**, **PulseLogger**, and **MythscribeGa
 ## Run the demo profile
 
 ```bash
-cargo run -- --trigger-loop --profile demo
+cargo run -- --trigger-loop --profile demo --ticks 10
 ```
 
-The demo profile scans your `scrolls/` directory. Any scroll tagged `pulse` awakens `PulseEcho`, which emits a bus message each tick. `PulseLogger` listens on the bus and records the activity in the invocation ledger.
+The demo profile scans your `scrolls/` directory. Any scroll tagged `pulse`
+automatically enables `PulseEcho` (interval defaults to one tick). Each cycle
+the orchestrator emits a "tick" message that `PulseLogger` records in the
+invocation ledger. When not running in CI, a second message is sent to
+`MythscribeGate` to showcase an additional ambient activation path.
 
 ## CI profile
 
 ```bash
-cargo run -- --trigger-loop --profile ci
+cargo run -- --trigger-loop --profile ci --ticks 3
 ```
 
-CI mode runs a small, deterministic number of ticks and short‑circuits heavy work in `MythscribeGate`.
+CI mode enforces deterministic behaviour: the engine uses a fixed seed, runs a
+bounded number of ticks (default 3, override with `--ticks`), and
+`MythscribeGate` logs quietly without extra work.
 
 ## Inspecting the ledger
 
@@ -30,6 +36,13 @@ After a run the ledger table will contain rows for each activation:
 
 ```bash
 sqlite3 scroll_core.db 'select invoked, phrase from invocation_ledger;'
+```
+
+Example rows:
+
+```
+pulse_echo|tick
+pulse_logger|tick
 ```
 
 Each `pulse_echo` tick produces a matching `pulse_logger` entry.

--- a/scroll_core/src/trigger_loom/orchestrator.rs
+++ b/scroll_core/src/trigger_loom/orchestrator.rs
@@ -1,35 +1,38 @@
-//! Ambient orchestrator skeleton for Trigger Loom → Invocation wiring.
+//! Ambient orchestrator for Trigger Loom → Invocation wiring.
 //!
-//! This module provides a minimal facade that can be extended to
-//! route ambient ticks into real construct invocations via the
-//! `InvocationManager` and ledger. For now it only logs intent.
+//! The orchestrator acts as a thin bridge between the
+//! [`TriggerLoopEngine`](crate::trigger_loom::engine::TriggerLoopEngine)
+//! and the [`Bus`](crate::orchestra::Bus). Each call to [`pump_once`]
+//! executes a single tick and enqueues demo invocations over the bus so
+//! listening constructs can react and log to the ledger.
 
 use crate::invocation::invocation_manager::InvocationManager;
-use crate::orchestra::Bus;
+use crate::invocation::named_construct::NamedConstruct;
+use crate::orchestra::{AgentMessage, Bus};
+use crate::trigger_loom::engine::TriggerLoopEngine;
+use serde_json::json;
+use uuid::Uuid;
 
 #[derive(Default, Clone)]
 pub struct AmbientOrchestratorConfig {
+    /// Maximum number of bus activations to enqueue per tick.
     pub max_invocations_per_tick: usize,
+    /// When true, CI mode disables non-deterministic demo paths.
+    pub ci_mode: bool,
 }
 
 pub struct AmbientOrchestrator {
-    pub bus: Option<Bus>,
     pub config: AmbientOrchestratorConfig,
 }
 
 impl AmbientOrchestrator {
     pub fn new() -> Self {
         Self {
-            bus: None,
             config: AmbientOrchestratorConfig {
                 max_invocations_per_tick: 1,
+                ci_mode: false,
             },
         }
-    }
-
-    pub fn with_bus(mut self, bus: Bus) -> Self {
-        self.bus = Some(bus);
-        self
     }
 
     pub fn with_config(mut self, config: AmbientOrchestratorConfig) -> Self {
@@ -37,14 +40,51 @@ impl AmbientOrchestrator {
         self
     }
 
-    /// Skeleton: Inspect bus state and, if any ambient triggers are present,
-    /// request up to `max_invocations_per_tick` invocations via the manager.
+    /// Run a single tick and enqueue demo invocations on the bus.
     ///
-    /// Currently this is a no-op that returns 0 to indicate no invocations.
-    pub fn pump_once(&mut self, _manager: &InvocationManager) -> usize {
-        // TODO: examine queued ambient events on the bus and map to constructs
-        // via InvocationManager. Log to ledger when wired.
-        0
+    /// Returns the number of activations dispatched over the bus.
+    #[allow(clippy::too_many_arguments)]
+    pub fn pump_once(
+        &mut self,
+        _manager: &InvocationManager,
+        constructs: &mut [Box<dyn NamedConstruct>],
+        engine: &mut TriggerLoopEngine,
+        bus: &Bus,
+    ) -> usize {
+        // Execute one tick. Constructs that are pulse sensitive will perform
+        // and log to the invocation ledger via the engine.
+        engine.tick_once(constructs);
+
+        // For the Phase 3 demo we simply broadcast a "tick" message to
+        // `pulse_logger` each cycle.  In non-CI runs we also notify the
+        // `mythscribe_gate` construct to demonstrate optional ambient
+        // activations.  These receivers handle ledger logging themselves.
+        let mut sent = 0usize;
+
+        if sent < self.config.max_invocations_per_tick {
+            let msg = AgentMessage {
+                id: Uuid::new_v4(),
+                from: "orchestrator".into(),
+                to: "pulse_logger".into(),
+                payload: json!({"text": "tick"}),
+                trace: vec!["loom".into()],
+            };
+            bus.send(msg);
+            sent += 1;
+        }
+
+        if !self.config.ci_mode && sent < self.config.max_invocations_per_tick {
+            let msg = AgentMessage {
+                id: Uuid::new_v4(),
+                from: "orchestrator".into(),
+                to: "mythscribe_gate".into(),
+                payload: json!({"text": "tick"}),
+                trace: vec!["loom".into()],
+            };
+            bus.send(msg);
+            sent += 1;
+        }
+
+        sent
     }
 }
-

--- a/scroll_core/tests/trigger_loom_ci_tests.rs
+++ b/scroll_core/tests/trigger_loom_ci_tests.rs
@@ -1,11 +1,13 @@
+use chrono::Utc;
+use scroll_core::core::cost_manager::InvocationCost;
 use scroll_core::invocation::constructs::{pulse_echo::PulseEcho, pulse_logger::PulseLogger};
+use scroll_core::invocation::invocation_manager::InvocationManager;
+use scroll_core::invocation::ledger_service::LedgerEvent;
+use scroll_core::invocation::types::{Invocation, InvocationMode, InvocationTier};
 use scroll_core::orchestra::{Bus, OrchestratedConstruct};
 use scroll_core::trigger_loom::config::TriggerLoopProfile;
 use scroll_core::trigger_loom::engine::TriggerLoopEngine;
-use scroll_core::invocation::ledger_service::LedgerEvent;
-use scroll_core::core::cost_manager::InvocationCost;
-use scroll_core::invocation::types::{Invocation, InvocationMode, InvocationTier};
-use chrono::Utc;
+use scroll_core::trigger_loom::orchestrator::{AmbientOrchestrator, AmbientOrchestratorConfig};
 use uuid::Uuid;
 
 #[test]
@@ -13,7 +15,9 @@ fn ci_profile_logs_pulses() {
     std::env::set_var("DATABASE_URL", "sqlite::memory:?cache=shared");
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
-        let _ = scroll_core::sessions::database::ensure_ready_with_url("sqlite::memory:?cache=shared").await;
+        let _ =
+            scroll_core::sessions::database::ensure_ready_with_url("sqlite::memory:?cache=shared")
+                .await;
     });
 
     let (ledger_handle, ledger_service) = scroll_core::invocation::ledger_service::start(64, 256);
@@ -27,10 +31,22 @@ fn ci_profile_logs_pulses() {
     let mut constructs: Vec<Box<dyn scroll_core::invocation::named_construct::NamedConstruct>> =
         vec![Box::new(echo)];
 
+    // Invocation manager placeholder (not used directly yet)
+    let manager = InvocationManager::new(Default::default()).with_ledger(ledger_handle.clone());
+
     let mut cfg = TriggerLoopProfile::Ci.config();
     cfg.max_invocations_per_tick = 1;
     let mut engine = TriggerLoopEngine::new(cfg).with_deterministic_seed(42);
-    engine.start_loop(&mut constructs, TriggerLoopProfile::Ci.tick_limit());
+
+    let mut orch = AmbientOrchestrator::new().with_config(AmbientOrchestratorConfig {
+        max_invocations_per_tick: 1,
+        ci_mode: true,
+    });
+
+    for _ in 0..TriggerLoopProfile::Ci.tick_limit().unwrap_or(3) {
+        orch.pump_once(&manager, &mut constructs, &mut engine, &bus);
+    }
+
     std::thread::sleep(std::time::Duration::from_millis(50));
     drop(constructs);
     drop(logger);
@@ -45,7 +61,10 @@ fn ci_profile_logs_pulses() {
         resonance_required: false,
         timestamp: Utc::now(),
     };
-    let _ = ledger_handle.try_log(LedgerEvent { invocation: invocation.clone(), cost: InvocationCost::default() });
+    let _ = ledger_handle.try_log(LedgerEvent {
+        invocation: invocation.clone(),
+        cost: InvocationCost::default(),
+    });
     let invocation2 = Invocation {
         id: Uuid::new_v4(),
         phrase: "tick".into(),
@@ -56,7 +75,10 @@ fn ci_profile_logs_pulses() {
         resonance_required: false,
         timestamp: Utc::now(),
     };
-    let _ = ledger_handle.try_log(LedgerEvent { invocation: invocation2, cost: InvocationCost::default() });
+    let _ = ledger_handle.try_log(LedgerEvent {
+        invocation: invocation2,
+        cost: InvocationCost::default(),
+    });
     drop(ledger_handle);
     // ensure ledger flushed
     ledger_service.shutdown_blocking(std::time::Duration::from_millis(250));


### PR DESCRIPTION
## Summary
- wire ambient orchestrator to trigger loop engine and bus
- document demo and ci profiles with tick limits and ledger queries
- cover orchestrator path with a deterministic CI test

## Testing
- `cargo test --test trigger_loom_ci_tests --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689922922a208330beed2fb9f1c8f075