### PR TITLE
Add doc maintenance helper script

### DIFF
--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,23 @@
+---
+title: Scroll Core Handbook
+status: active
+audience: dev
+---
+
+# Scroll Core Handbook
+
+## Documentation Maintenance
+
+Run the `tools/doc_maintenance` helper to regenerate the documentation indexes in one step.
+
+```sh
+./tools/doc_maintenance
+```
+
+The command runs the following actions sequentially and reports a summary at the end:
+
+1. `cargo run -- doc --action index`
+2. `cargo run -- doc --action normalize`
+3. `cargo run -- doc --action classify`
+
+If any action fails, the helper exits with a non-zero code so CI or local scripts can detect the failure quickly. Use the standard cargo output from each step to diagnose issues.

--- a/tools/doc_maintenance
+++ b/tools/doc_maintenance
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+cd "$ROOT_DIR" || {
+  echo "Failed to change directory to repository root." >&2
+  exit 1
+}
+
+ACTIONS=(index normalize classify)
+RESULTS=()
+STATUS=0
+
+echo "Scroll Core documentation maintenance"
+echo "Repo: $ROOT_DIR"
+echo
+
+for action in "${ACTIONS[@]}"; do
+  echo "Running: cargo run -- doc --action $action"
+  if cargo run -- doc --action "$action"; then
+    printf "Result: %s - OK\n\n" "$action"
+    RESULTS+=("0")
+  else
+    printf "Result: %s - FAILED\n\n" "$action"
+    RESULTS+=("1")
+    STATUS=1
+  fi
+done
+
+echo "Summary:"
+for idx in "${!ACTIONS[@]}"; do
+  action="${ACTIONS[$idx]}"
+  result="${RESULTS[$idx]}"
+  if [ "$result" -eq 0 ]; then
+    printf "  [OK]   %s\n" "$action"
+  else
+    printf "  [FAIL] %s\n" "$action"
+  fi
+done
+
+echo
+if [ "$STATUS" -ne 0 ]; then
+  echo "One or more documentation maintenance steps failed." >&2
+  exit "$STATUS"
+else
+  echo "All documentation maintenance steps completed successfully."
+fi


### PR DESCRIPTION
## Summary
- add a `tools/doc_maintenance` helper that runs the doc index/normalize/classify actions with a summarized result and failure handling
- document the new one-step workflow in `docs/handbook/README.md`

## Testing
- ./tools/doc_maintenance

------
https://chatgpt.com/codex/tasks/task_e_68cc0b5557a48330ad3d2852c17aaa04